### PR TITLE
feat: implement memo setup command (S-002)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -21,6 +21,10 @@ export default tseslint.config(
       },
     },
     rules: {
+      '@typescript-eslint/no-unnecessary-condition': [
+        'error',
+        { allowConstantLoopConditions: true },
+      ],
       '@typescript-eslint/no-unused-vars': [
         'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -17,10 +17,14 @@ const config: Config = {
       },
     ],
   },
-  collectCoverageFrom: [
-    'src/**/*.ts',
-    '!src/index.ts',
-  ],
+  // chalk@5 and ora@8 are ESM-only; map to CommonJS stubs for Jest.
+  // Strip .js extensions from relative imports so CJS resolution finds the .ts source.
+  moduleNameMapper: {
+    '^chalk$': '<rootDir>/tests/__mocks__/chalk.cjs',
+    '^ora$': '<rootDir>/tests/__mocks__/ora.cjs',
+    '^(\\.{1,2}/.+)\\.js$': '$1',
+  },
+  collectCoverageFrom: ['src/**/*.ts', '!src/index.ts'],
   coverageThreshold: {
     global: {
       lines: 80,

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,2 +1,354 @@
-// TODO: Implement in S-002 — memo setup init | show | validate
-export {};
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { createInterface } from 'node:readline/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { loadConfig, writeConfig, validateConfig } from '../lib/config.js';
+import { MemoConfigSchema } from '../types/config.js';
+import type { MemoConfig } from '../types/config.js';
+import { MemoError } from '../lib/errors.js';
+
+const KEBAB_CASE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+const CONFIG_FILE = 'memo.config.json';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getGitRemoteRepo(): string | undefined {
+  try {
+    const url = execSync('git remote get-url origin', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    const match = /\/([^/]+?)(?:\.git)?$/.exec(url);
+    return match?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
+async function promptField(
+  rl: ReturnType<typeof createInterface>,
+  label: string,
+  hint: string,
+  defaultValue: string,
+  validator: (v: string) => string | null,
+): Promise<string> {
+  const defaultDisplay = defaultValue ? chalk.gray(`(${defaultValue})`) : '';
+  while (true) {
+    const raw = await rl.question(`║  ${chalk.cyan(label)}  ${hint} ${defaultDisplay}›  `);
+    const value = raw.trim() || defaultValue;
+    const error = validator(value);
+    if (error) {
+      process.stdout.write(`║  ${chalk.red(`✗ ${error}`)}\n`);
+      continue;
+    }
+    return value;
+  }
+}
+
+async function promptSelect(
+  rl: ReturnType<typeof createInterface>,
+  label: string,
+  options: readonly string[],
+  defaultValue: string,
+): Promise<string> {
+  const optionsDisplay = options.join(' / ');
+  while (true) {
+    const raw = await rl.question(
+      `║  ${chalk.cyan(label)}  [${optionsDisplay}]  ›  ${chalk.gray(defaultValue)}  `,
+    );
+    const value = raw.trim() || defaultValue;
+    if ((options as string[]).includes(value)) {
+      return value;
+    }
+    process.stdout.write(`║  ${chalk.red(`✗ Choose one of: ${optionsDisplay}`)}\n`);
+  }
+}
+
+async function confirmOverwrite(
+  rl: ReturnType<typeof createInterface>,
+  cwd: string,
+): Promise<boolean> {
+  const filePath = join(cwd, CONFIG_FILE);
+  if (!existsSync(filePath)) return true;
+
+  process.stdout.write(
+    `\n  ${chalk.yellow.bold('⚠')}  ${chalk.yellow(`${CONFIG_FILE} already exists.`)}\n`,
+  );
+  const answer = await rl.question(`  Overwrite existing config?  [y/N]  `);
+  return answer.trim().toLowerCase() === 'y';
+}
+
+// ---------------------------------------------------------------------------
+// Interactive wizard
+// ---------------------------------------------------------------------------
+
+async function runInteractiveWizard(cwd: string): Promise<MemoConfig | null> {
+  const suggestedRepo = getGitRemoteRepo() ?? '';
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+  try {
+    process.stdout.write(`${chalk.cyan('╔')}  ${chalk.bold('Memo Setup')}\n║\n`);
+
+    const repo = await promptField(rl, 'Repo name', '(kebab-case)', suggestedRepo, (v) =>
+      !v ? 'Required' : !KEBAB_CASE.test(v) ? 'Must be kebab-case' : null,
+    );
+
+    const org = await promptField(rl, 'Org      ', '(kebab-case)', '', (v) =>
+      !v ? 'Required' : !KEBAB_CASE.test(v) ? 'Must be kebab-case' : null,
+    );
+
+    const domain = await promptField(rl, 'Domain   ', '(kebab-case)', '', (v) =>
+      !v ? 'Required' : !KEBAB_CASE.test(v) ? 'Must be kebab-case' : null,
+    );
+
+    const relatesRaw = await promptField(
+      rl,
+      'Related repos',
+      '(comma-separated, optional)',
+      '',
+      (v) => {
+        if (!v) return null;
+        const items = v
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+        for (const item of items) {
+          if (!KEBAB_CASE.test(item)) return `"${item}" must be kebab-case`;
+          if (item === repo) return `"${item}" must not equal repo`;
+        }
+        const seen = new Set(items);
+        if (seen.size !== items.length) return 'Duplicate entries';
+        return null;
+      },
+    );
+
+    const source = await promptSelect(rl, 'Default source', ['agent', 'manual'], 'agent');
+    const searchScope = await promptSelect(rl, 'Default scope ', ['repo', 'related'], 'repo');
+
+    process.stdout.write(`${chalk.cyan('╚')}\n`);
+
+    const relatesTo = relatesRaw
+      ? relatesRaw
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : [];
+
+    const config: MemoConfig = MemoConfigSchema.parse({
+      schema_version: '1',
+      repo,
+      org,
+      domain,
+      relates_to: relatesTo,
+      defaults: { source, search_scope: searchScope },
+    });
+
+    // Preview
+    process.stdout.write(`\n  Preview:\n\n`);
+    const preview = JSON.stringify(config, null, 2)
+      .split('\n')
+      .map((l) => `  ${l}`)
+      .join('\n');
+    process.stdout.write(`${preview}\n\n`);
+
+    if (!(await confirmOverwrite(rl, cwd))) {
+      process.stdout.write(chalk.yellow('  Aborted.\n'));
+      return null;
+    }
+
+    const confirm = await rl.question(
+      `  ${chalk.green('✔')}  Write ${chalk.bold(CONFIG_FILE)}?  [Y/n]  `,
+    );
+    if (confirm.trim().toLowerCase() === 'n') {
+      process.stdout.write(chalk.yellow('  Aborted.\n'));
+      return null;
+    }
+
+    return config;
+  } finally {
+    rl.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// setup init
+// ---------------------------------------------------------------------------
+
+interface InitOptions {
+  repo?: string;
+  org?: string;
+  domain?: string;
+  relatesTo?: string;
+  json?: boolean;
+}
+
+async function handleInit(opts: InitOptions, cwd: string): Promise<void> {
+  const isNonInteractive =
+    opts.repo !== undefined ||
+    opts.org !== undefined ||
+    opts.domain !== undefined ||
+    opts.relatesTo !== undefined;
+
+  let config: MemoConfig | null;
+
+  if (isNonInteractive) {
+    // Non-interactive path: validate flags and write immediately
+    if (!opts.repo)
+      throw new MemoError('CONFIG_INVALID', '--repo is required in non-interactive mode');
+    if (!opts.org)
+      throw new MemoError('CONFIG_INVALID', '--org is required in non-interactive mode');
+    if (!opts.domain)
+      throw new MemoError('CONFIG_INVALID', '--domain is required in non-interactive mode');
+
+    const relatesTo = opts.relatesTo
+      ? opts.relatesTo
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : [];
+
+    const result = MemoConfigSchema.safeParse({
+      schema_version: '1',
+      repo: opts.repo,
+      org: opts.org,
+      domain: opts.domain,
+      relates_to: relatesTo,
+      defaults: {},
+    });
+
+    if (!result.success) {
+      const issues = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+      throw new MemoError('CONFIG_INVALID', `Invalid config: ${issues}`);
+    }
+
+    config = result.data;
+
+    // Warn if overwriting (non-interactive: still check but skip confirmation)
+    const filePath = join(cwd, CONFIG_FILE);
+    if (existsSync(filePath)) {
+      process.stderr.write(chalk.yellow(`Warning: overwriting existing ${CONFIG_FILE}\n`));
+    }
+  } else {
+    config = await runInteractiveWizard(cwd);
+  }
+
+  if (!config) return;
+
+  await writeConfig(config, cwd);
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(config, null, 2) + '\n');
+  } else {
+    process.stdout.write(chalk.green(`  ✔  Written ${join(cwd, CONFIG_FILE)}\n`));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// setup show
+// ---------------------------------------------------------------------------
+
+interface ShowOptions {
+  json?: boolean;
+}
+
+async function handleShow(opts: ShowOptions, cwd: string): Promise<void> {
+  const config = await loadConfig(cwd);
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(config, null, 2) + '\n');
+  } else {
+    process.stdout.write(chalk.bold('Memo Configuration\n'));
+    process.stdout.write('─'.repeat(40) + '\n');
+    process.stdout.write(JSON.stringify(config, null, 2) + '\n');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// setup validate
+// ---------------------------------------------------------------------------
+
+async function handleValidate(cwd: string): Promise<void> {
+  const result = await validateConfig(cwd);
+
+  if (result.valid) {
+    process.stdout.write(chalk.green(`✔ ${CONFIG_FILE} is valid\n`));
+    process.exit(0);
+  } else {
+    process.stderr.write(chalk.red(`✗ ${CONFIG_FILE} is invalid\n`));
+    if (result.errors) {
+      for (const err of result.errors) {
+        process.stderr.write(chalk.red(`  • ${err}\n`));
+      }
+    }
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command tree
+// ---------------------------------------------------------------------------
+
+const setupInit = new Command('init')
+  .description('Initialize Memo repository configuration')
+  .option('--repo <name>', 'Repository name (kebab-case)')
+  .option('--org <name>', 'Organization (kebab-case)')
+  .option('--domain <name>', 'Domain (kebab-case)')
+  .option('--relates-to <repos>', 'Comma-separated related repos')
+  .option('--json', 'Output written config as JSON to stdout')
+  .action(async function (this: Command) {
+    const opts = this.opts<InitOptions>();
+    try {
+      await handleInit(opts, process.cwd());
+    } catch (err) {
+      if (err instanceof MemoError) {
+        process.stderr.write(chalk.red(`Error [${err.code}]: ${err.message}\n`));
+        process.exit(err.exitCode);
+      }
+      throw err;
+    }
+  });
+
+const setupShow = new Command('show')
+  .description('Show effective Memo configuration')
+  .option('--json', 'Output as JSON')
+  .action(async function (this: Command) {
+    const opts = this.opts<ShowOptions>();
+    try {
+      await handleShow(opts, process.cwd());
+    } catch (err) {
+      if (err instanceof MemoError) {
+        process.stderr.write(chalk.red(`Error [${err.code}]: ${err.message}\n`));
+        process.exit(err.exitCode);
+      }
+      throw err;
+    }
+  });
+
+const setupValidate = new Command('validate')
+  .description('Validate Memo configuration; exits 0 if valid, 1 if invalid')
+  .action(async () => {
+    try {
+      await handleValidate(process.cwd());
+    } catch (err) {
+      if (err instanceof MemoError) {
+        process.stderr.write(chalk.red(`Error [${err.code}]: ${err.message}\n`));
+        process.exit(err.exitCode);
+      }
+      throw err;
+    }
+  });
+
+const setup = new Command('setup').description('Manage Memo repository configuration');
+setup.addCommand(setupInit);
+setup.addCommand(setupShow);
+setup.addCommand(setupValidate);
+
+export default setup;
+
+// Named exports for testing
+export { handleInit, handleShow, handleValidate };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,24 +3,24 @@ import { program } from 'commander';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import setup from './commands/setup.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const pkg = JSON.parse(
-  readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'),
-) as { version: string };
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')) as {
+  version: string;
+};
 
 program
   .name('memo')
   .description('Agent-first CLI for capturing and querying development decisions')
   .version(pkg.version);
 
-// Commands registered here in subsequent stories
-// program.addCommand(require('./commands/setup').default);
-// program.addCommand(require('./commands/write').default);
-// program.addCommand(require('./commands/search').default);
-// program.addCommand(require('./commands/list').default);
+program.addCommand(setup);
+// program.addCommand(write);   // S-004
+// program.addCommand(search);  // S-005
+// program.addCommand(list);    // S-006
 
 program.parseAsync(process.argv).catch((err: unknown) => {
   const message = err instanceof Error ? err.message : String(err);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,67 @@
-// TODO: Implement in S-002 — Config loader, writer, validator
-export {};
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { MemoConfigSchema } from '../types/config.js';
+import type { MemoConfig } from '../types/config.js';
+import { MemoError } from './errors.js';
+
+const CONFIG_FILENAME = 'memo.config.json';
+
+export async function loadConfig(cwd: string = process.cwd()): Promise<MemoConfig> {
+  const filePath = join(cwd, CONFIG_FILENAME);
+  let raw: string;
+  try {
+    raw = await readFile(filePath, 'utf-8');
+  } catch {
+    throw new MemoError('CONFIG_NOT_FOUND', `Config file not found: ${filePath}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    throw new MemoError('CONFIG_INVALID', `Config file is not valid JSON: ${filePath}`);
+  }
+
+  const result = MemoConfigSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+    throw new MemoError('CONFIG_INVALID', `Config is invalid: ${issues}`);
+  }
+
+  return result.data;
+}
+
+export async function writeConfig(config: MemoConfig, cwd: string = process.cwd()): Promise<void> {
+  const filePath = join(cwd, CONFIG_FILENAME);
+  await writeFile(filePath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}
+
+export interface ValidateConfigResult {
+  valid: boolean;
+  errors?: string[];
+}
+
+export async function validateConfig(cwd: string = process.cwd()): Promise<ValidateConfigResult> {
+  const filePath = join(cwd, CONFIG_FILENAME);
+  let raw: string;
+  try {
+    raw = await readFile(filePath, 'utf-8');
+  } catch {
+    return { valid: false, errors: [`Config file not found: ${filePath}`] };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    return { valid: false, errors: ['Config file is not valid JSON'] };
+  }
+
+  const result = MemoConfigSchema.safeParse(parsed);
+  if (!result.success) {
+    const errors = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+    return { valid: false, errors };
+  }
+
+  return { valid: true };
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,2 +1,51 @@
-// TODO: Implement in S-002 — MemoConfig Zod schema + types
-export {};
+import { z } from 'zod';
+
+const KEBAB_CASE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+
+const KebabString = z
+  .string()
+  .regex(KEBAB_CASE, 'Must be kebab-case (lowercase letters, digits, hyphens only)');
+
+export const MemoConfigSchema = z
+  .object({
+    schema_version: z.literal('1'),
+    repo: KebabString,
+    org: KebabString,
+    domain: KebabString,
+    relates_to: z.array(KebabString).optional().default([]),
+    defaults: z
+      .object({
+        source: z.enum(['agent', 'manual']).default('agent'),
+        search_scope: z.enum(['repo', 'related']).default('repo'),
+      })
+      .default({}),
+  })
+  .passthrough()
+  .superRefine((data, ctx) => {
+    const relates = data.relates_to;
+    const seen = new Set<string>();
+
+    for (let i = 0; i < relates.length; i++) {
+      const r = relates[i];
+      if (r === undefined) continue;
+
+      if (seen.has(r)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['relates_to', i],
+          message: `Duplicate entry: "${r}"`,
+        });
+      }
+      seen.add(r);
+
+      if (r === data.repo) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['relates_to', i],
+          message: `"${r}" must not equal repo`,
+        });
+      }
+    }
+  });
+
+export type MemoConfig = z.infer<typeof MemoConfigSchema>;

--- a/tests/__mocks__/chalk.cjs
+++ b/tests/__mocks__/chalk.cjs
@@ -1,0 +1,22 @@
+// CommonJS stub for chalk@5 (ESM-only) to allow Jest tests to run in CJS mode.
+// All chalk methods return the input string unchanged.
+'use strict';
+
+function createChalk() {
+  const fn = function (...args) {
+    return args.join(' ');
+  };
+  return new Proxy(fn, {
+    get(_target, prop) {
+      if (prop === 'level') return 0;
+      return createChalk();
+    },
+    apply(_target, _thisArg, args) {
+      return args.join(' ');
+    },
+  });
+}
+
+const chalk = createChalk();
+module.exports = chalk;
+module.exports.default = chalk;

--- a/tests/__mocks__/ora.cjs
+++ b/tests/__mocks__/ora.cjs
@@ -1,0 +1,19 @@
+// CommonJS stub for ora@8 (ESM-only) to allow Jest tests to run in CJS mode.
+'use strict';
+
+function createSpinner() {
+  return {
+    start: () => createSpinner(),
+    stop: () => createSpinner(),
+    succeed: () => createSpinner(),
+    fail: () => createSpinner(),
+    warn: () => createSpinner(),
+    info: () => createSpinner(),
+    text: '',
+  };
+}
+
+module.exports = function ora() {
+  return createSpinner();
+};
+module.exports.default = module.exports;

--- a/tests/integration/commands/setup.test.ts
+++ b/tests/integration/commands/setup.test.ts
@@ -1,0 +1,223 @@
+import { mkdtemp, readFile, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { handleInit, handleShow, handleValidate } from '../../../src/commands/setup';
+import { MemoConfigSchema } from '../../../src/types/config';
+
+const VALID_CONFIG = {
+  schema_version: '1' as const,
+  repo: 'test-repo',
+  org: 'test-org',
+  domain: 'test-domain',
+  relates_to: [] as string[],
+  defaults: { source: 'agent' as const, search_scope: 'repo' as const },
+};
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'memo-test-'));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// setup init (non-interactive)
+// ---------------------------------------------------------------------------
+
+describe('setup init (non-interactive)', () => {
+  it('creates memo.config.json in the target directory', async () => {
+    await handleInit({ repo: 'test-repo', org: 'test-org', domain: 'test-domain' }, tmpDir);
+
+    const content = await readFile(join(tmpDir, 'memo.config.json'), 'utf-8');
+    const parsed: unknown = JSON.parse(content);
+    const result = MemoConfigSchema.safeParse(parsed);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.repo).toBe('test-repo');
+      expect(result.data.org).toBe('test-org');
+      expect(result.data.domain).toBe('test-domain');
+      expect(result.data.schema_version).toBe('1');
+    }
+  });
+
+  it('parses comma-separated --relates-to flag', async () => {
+    await handleInit(
+      {
+        repo: 'my-app',
+        org: 'acme',
+        domain: 'backend',
+        relatesTo: 'other-service,third-service',
+      },
+      tmpDir,
+    );
+
+    const content = await readFile(join(tmpDir, 'memo.config.json'), 'utf-8');
+    const parsed: unknown = JSON.parse(content);
+    const result = MemoConfigSchema.safeParse(parsed);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.relates_to).toEqual(['other-service', 'third-service']);
+    }
+  });
+
+  it('throws CONFIG_INVALID when --repo is missing in non-interactive mode', async () => {
+    await expect(
+      handleInit({ org: 'test-org', domain: 'test-domain' }, tmpDir),
+    ).rejects.toMatchObject({ code: 'CONFIG_INVALID' });
+  });
+
+  it('throws CONFIG_INVALID when --org is missing in non-interactive mode', async () => {
+    await expect(
+      handleInit({ repo: 'test-repo', domain: 'test-domain' }, tmpDir),
+    ).rejects.toMatchObject({ code: 'CONFIG_INVALID' });
+  });
+
+  it('throws CONFIG_INVALID when repo is not kebab-case', async () => {
+    await expect(
+      handleInit({ repo: 'TestRepo', org: 'test-org', domain: 'test-domain' }, tmpDir),
+    ).rejects.toMatchObject({ code: 'CONFIG_INVALID' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setup init --json
+// ---------------------------------------------------------------------------
+
+describe('setup init --json', () => {
+  it('writes config and outputs JSON to stdout', async () => {
+    const lines: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      lines.push(String(chunk));
+      return true;
+    };
+
+    try {
+      await handleInit(
+        { repo: 'json-repo', org: 'json-org', domain: 'json-domain', json: true },
+        tmpDir,
+      );
+    } finally {
+      process.stdout.write = origWrite;
+    }
+
+    const stdout = lines.join('');
+    const parsed: unknown = JSON.parse(stdout);
+    const result = MemoConfigSchema.safeParse(parsed);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.repo).toBe('json-repo');
+    }
+
+    // File should also be written
+    const content = await readFile(join(tmpDir, 'memo.config.json'), 'utf-8');
+    expect(content).toContain('json-repo');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setup show
+// ---------------------------------------------------------------------------
+
+describe('setup show', () => {
+  beforeEach(async () => {
+    await writeFile(join(tmpDir, 'memo.config.json'), JSON.stringify(VALID_CONFIG, null, 2) + '\n');
+  });
+
+  it('outputs config as JSON when --json flag is set', async () => {
+    const lines: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (chunk: string | Uint8Array) => {
+      lines.push(String(chunk));
+      return true;
+    };
+
+    try {
+      await handleShow({ json: true }, tmpDir);
+    } finally {
+      process.stdout.write = origWrite;
+    }
+
+    const stdout = lines.join('');
+    const parsed: unknown = JSON.parse(stdout);
+    const result = MemoConfigSchema.safeParse(parsed);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.repo).toBe('test-repo');
+    }
+  });
+
+  it('throws CONFIG_NOT_FOUND when no config file exists', async () => {
+    await expect(handleShow({}, join(tmpDir, 'nonexistent'))).rejects.toMatchObject({
+      code: 'CONFIG_NOT_FOUND',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setup validate
+// ---------------------------------------------------------------------------
+
+describe('setup validate', () => {
+  it('exits 0 (valid) for a correctly structured config', async () => {
+    await writeFile(join(tmpDir, 'memo.config.json'), JSON.stringify(VALID_CONFIG, null, 2) + '\n');
+
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit(${String(code)})`);
+    });
+
+    try {
+      await handleValidate(tmpDir);
+      // If handleValidate doesn't call exit(0) itself and just returns, that's also valid
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      expect(msg).toBe('process.exit(0)');
+    } finally {
+      mockExit.mockRestore();
+    }
+  });
+
+  it('exits 1 for an invalid config', async () => {
+    await writeFile(
+      join(tmpDir, 'memo.config.json'),
+      JSON.stringify({ schema_version: '1', repo: 'InvalidRepo' }, null, 2),
+    );
+
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit(${String(code)})`);
+    });
+
+    try {
+      await handleValidate(tmpDir);
+      fail('Expected process.exit to be called');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      expect(msg).toBe('process.exit(1)');
+    } finally {
+      mockExit.mockRestore();
+    }
+  });
+
+  it('exits 1 when memo.config.json does not exist', async () => {
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit(${String(code)})`);
+    });
+
+    try {
+      await handleValidate(join(tmpDir, 'nonexistent-dir'));
+      fail('Expected process.exit to be called');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      expect(msg).toBe('process.exit(1)');
+    } finally {
+      mockExit.mockRestore();
+    }
+  });
+});

--- a/tests/unit/lib/config.test.ts
+++ b/tests/unit/lib/config.test.ts
@@ -1,0 +1,231 @@
+import { MemoConfigSchema } from '../../../src/types/config';
+
+const VALID_BASE = {
+  schema_version: '1' as const,
+  repo: 'my-app',
+  org: 'acme-corp',
+  domain: 'developer-tools',
+};
+
+describe('MemoConfigSchema', () => {
+  // ---------------------------------------------------------------------------
+  // Valid inputs
+  // ---------------------------------------------------------------------------
+
+  it('accepts a minimal valid config', () => {
+    const result = MemoConfigSchema.safeParse(VALID_BASE);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.relates_to).toEqual([]);
+      expect(result.data.defaults.source).toBe('agent');
+      expect(result.data.defaults.search_scope).toBe('repo');
+    }
+  });
+
+  it('accepts a full valid config', () => {
+    const result = MemoConfigSchema.safeParse({
+      ...VALID_BASE,
+      relates_to: ['other-repo', 'third-repo'],
+      defaults: { source: 'manual', search_scope: 'related' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts repo names with digits and hyphens', () => {
+    const result = MemoConfigSchema.safeParse({
+      ...VALID_BASE,
+      repo: 'my-app-v2',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Defaults
+  // ---------------------------------------------------------------------------
+
+  it('defaults relates_to to empty array when omitted', () => {
+    const result = MemoConfigSchema.safeParse(VALID_BASE);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.relates_to).toEqual([]);
+    }
+  });
+
+  it('defaults defaults.source to "agent"', () => {
+    const result = MemoConfigSchema.safeParse(VALID_BASE);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.defaults.source).toBe('agent');
+    }
+  });
+
+  it('defaults defaults.search_scope to "repo"', () => {
+    const result = MemoConfigSchema.safeParse(VALID_BASE);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.defaults.search_scope).toBe('repo');
+    }
+  });
+
+  it('defaults entire defaults object when omitted', () => {
+    const result = MemoConfigSchema.safeParse(VALID_BASE);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.defaults).toEqual({ source: 'agent', search_scope: 'repo' });
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Unknown-key passthrough
+  // ---------------------------------------------------------------------------
+
+  it('passes through unknown keys without error', () => {
+    const result = MemoConfigSchema.safeParse({
+      ...VALID_BASE,
+      future_field: 'some-value',
+      nested_future: { a: 1 },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as Record<string, unknown>)['future_field']).toBe('some-value');
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Required field validation
+  // ---------------------------------------------------------------------------
+
+  it('rejects missing schema_version', () => {
+    const { schema_version: _sv, ...rest } = VALID_BASE;
+    const result = MemoConfigSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects wrong schema_version literal', () => {
+    const result = MemoConfigSchema.safeParse({ ...VALID_BASE, schema_version: '2' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing repo', () => {
+    const { repo: _r, ...rest } = VALID_BASE;
+    const result = MemoConfigSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing org', () => {
+    const { org: _o, ...rest } = VALID_BASE;
+    const result = MemoConfigSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing domain', () => {
+    const { domain: _d, ...rest } = VALID_BASE;
+    const result = MemoConfigSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Kebab-case validation
+  // ---------------------------------------------------------------------------
+
+  it('rejects repo with uppercase letters', () => {
+    const result = MemoConfigSchema.safeParse({ ...VALID_BASE, repo: 'MyApp' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects repo with spaces', () => {
+    const result = MemoConfigSchema.safeParse({ ...VALID_BASE, repo: 'my app' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects repo with leading hyphen', () => {
+    const result = MemoConfigSchema.safeParse({ ...VALID_BASE, repo: '-my-app' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects repo with trailing hyphen', () => {
+    const result = MemoConfigSchema.safeParse({ ...VALID_BASE, repo: 'my-app-' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects repo with underscores', () => {
+    const result = MemoConfigSchema.safeParse({ ...VALID_BASE, repo: 'my_app' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-kebab-case org', () => {
+    const result = MemoConfigSchema.safeParse({ ...VALID_BASE, org: 'AcmeCorp' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-kebab-case domain', () => {
+    const result = MemoConfigSchema.safeParse({ ...VALID_BASE, domain: 'Developer Tools' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-kebab-case entry in relates_to', () => {
+    const result = MemoConfigSchema.safeParse({
+      ...VALID_BASE,
+      relates_to: ['valid-repo', 'Invalid_Repo'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------------
+  // relates_to cross-field validation
+  // ---------------------------------------------------------------------------
+
+  it('rejects duplicate entries in relates_to', () => {
+    const result = MemoConfigSchema.safeParse({
+      ...VALID_BASE,
+      relates_to: ['other-repo', 'other-repo'],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages.some((m) => m.includes('Duplicate'))).toBe(true);
+    }
+  });
+
+  it('rejects relates_to entry equal to repo', () => {
+    const result = MemoConfigSchema.safeParse({
+      ...VALID_BASE,
+      repo: 'my-app',
+      relates_to: ['my-app'],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages.some((m) => m.includes('must not equal repo'))).toBe(true);
+    }
+  });
+
+  it('accepts relates_to with no duplicates and no self-reference', () => {
+    const result = MemoConfigSchema.safeParse({
+      ...VALID_BASE,
+      repo: 'my-app',
+      relates_to: ['other-repo', 'third-repo'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // defaults validation
+  // ---------------------------------------------------------------------------
+
+  it('rejects invalid defaults.source value', () => {
+    const result = MemoConfigSchema.safeParse({
+      ...VALID_BASE,
+      defaults: { source: 'unknown', search_scope: 'repo' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid defaults.search_scope value', () => {
+    const result = MemoConfigSchema.safeParse({
+      ...VALID_BASE,
+      defaults: { source: 'agent', search_scope: 'global' },
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements Story S-002: `memo setup` — Repository Initialization and Config Management.

Closes #2

## Changes

### New Files
- `src/types/config.ts` — `MemoConfig` Zod schema with kebab-case validation, `relates_to` dedup/self-ref guard, unknown-key passthrough
- `src/lib/config.ts` — `loadConfig()`, `writeConfig()`, `validateConfig()` with `CONFIG_NOT_FOUND` / `CONFIG_INVALID` error codes
- `tests/__mocks__/chalk.cjs` — CommonJS stub for ESM-only chalk (Jest compat)
- `tests/__mocks__/ora.cjs` — CommonJS stub for ESM-only ora (Jest compat)
- `tests/unit/lib/config.test.ts` — 22 unit tests covering schema validation
- `tests/integration/commands/setup.test.ts` — 11 integration tests covering init/show/validate

### Modified Files
- `src/commands/setup.ts` — Full `setup init|show|validate` implementation (interactive wizard, non-interactive flags, git remote auto-detect, overwrite protection, `--json` output)
- `src/index.ts` — Register `setup` command
- `jest.config.ts` — Add chalk/ora CJS module name mappers for test compatibility
- `eslint.config.ts` — Allow `while(true)` constant loop conditions

## Test Results

All 38 tests pass:
- `tests/unit/scaffold.test.ts` (1 test)
- `tests/unit/lib/config.test.ts` (22 tests)
- `tests/integration/commands/setup.test.ts` (11 tests)

## Acceptance Criteria

- [x] `memo setup init` creates valid `memo.config.json` in empty directory
- [x] Interactive wizard shows preview and confirmation prompt
- [x] Non-interactive mode (`--repo`, `--org`, `--domain`, `--relates-to`) skips prompts
- [x] `memo setup validate` exits 0/1 correctly
- [x] `--json` output returns written config as JSON