### PR TITLE
feat(search): implement memo search command

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ memo write \
 # Search decisions
 memo search "why did we choose the vector database"
 
+# Search within related repos and require tags
+memo search "how do we persist decisions" \
+  --scope related \
+  --tags "qdrant,write-flow"
+
+# Machine-readable search output
+memo search "how do we persist decisions" --json
+
 # List recent entries
 memo list --limit 10
 ```

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "jest",
+    "test": "node ./scripts/run-jest.mjs",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "prepare": "husky",

--- a/scripts/run-jest.mjs
+++ b/scripts/run-jest.mjs
@@ -1,0 +1,28 @@
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const jestPackageJson = require.resolve('jest/package.json');
+const jestBin = join(dirname(jestPackageJson), 'bin', 'jest.js');
+const forwardedArgs = process.argv.slice(2);
+const args = forwardedArgs[0] === '--' ? forwardedArgs.slice(1) : forwardedArgs;
+
+const child = spawn(process.execPath, [jestBin, ...args], {
+  stdio: 'inherit',
+  env: process.env,
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 1);
+});
+
+child.on('error', (error) => {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+});

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,2 +1,219 @@
-// TODO: Implement in S-005 — memo search
-export {};
+import { Command } from 'commander';
+import { loadConfig } from '../lib/config.js';
+import { createEmbeddingsAdapter } from '../lib/embeddings.js';
+import { MemoError } from '../lib/errors.js';
+import { output } from '../lib/output.js';
+import { QdrantRepository } from '../lib/qdrant.js';
+import { resolveScopeRepos } from '../lib/registry.js';
+import { buildSearchFilters } from '../lib/search-filters.js';
+import type { MemoConfig } from '../types/config.js';
+import type { SearchResult } from '../lib/qdrant.js';
+
+export interface SearchFlags {
+  query: string;
+  scope?: string;
+  repo?: string;
+  org?: string;
+  tags?: string;
+  entryType?: string;
+  source?: string;
+  limit?: string | number;
+  json?: boolean;
+}
+
+export interface SearchDeps {
+  loadCfg?: typeof loadConfig;
+  createRepo?: (url?: string, key?: string) => QdrantRepository;
+  createEmbeddings?: typeof createEmbeddingsAdapter;
+  resolveRepos?: typeof resolveScopeRepos;
+}
+
+export interface SearchResponseFilters {
+  scope: 'repo' | 'related';
+  repo: string;
+  org?: string;
+  tags?: string[];
+  entry_type?: string[];
+  source?: string[];
+  limit: number;
+}
+
+function parseCsv(value?: string): string[] {
+  if (!value) return [];
+  return [
+    ...new Set(
+      value
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0),
+    ),
+  ];
+}
+
+function parseScope(value: string | undefined, config?: MemoConfig | null): 'repo' | 'related' {
+  const scope = value ?? config?.defaults.search_scope ?? 'repo';
+  if (scope !== 'repo' && scope !== 'related') {
+    throw new MemoError(
+      'VALIDATION_FAILED',
+      `Invalid --scope value "${scope}". Use repo or related.`,
+    );
+  }
+  return scope;
+}
+
+function parseLimit(value: string | number | undefined): number {
+  if (value === undefined) return 10;
+  const parsed = typeof value === 'number' ? value : Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new MemoError('VALIDATION_FAILED', '--limit must be a positive integer.');
+  }
+  return parsed;
+}
+
+export function buildSearchVectorInput(query: string, tags: string[]): string {
+  return tags.length > 0 ? `${query} ${tags.join(' ')}` : query;
+}
+
+function buildActiveFilters(filters: SearchResponseFilters, repoSet: string[]): string[] {
+  const values = [`scope:${filters.scope}`, `repo:${repoSet.join(',')}`];
+  if (filters.org) values.push(`org:${filters.org}`);
+  if (filters.tags && filters.tags.length > 0) values.push(`tags:${filters.tags.join(',')}`);
+  if (filters.entry_type && filters.entry_type.length > 0) {
+    values.push(`entry_type:${filters.entry_type.join(',')}`);
+  }
+  if (filters.source && filters.source.length > 0) {
+    values.push(`source:${filters.source.join(',')}`);
+  }
+  values.push(`limit:${String(filters.limit)}`);
+  return values;
+}
+
+function toJsonResult(result: SearchResult): Record<string, unknown> {
+  return {
+    id: result.id,
+    ...(result.payload ?? {}),
+    similarity: result.score,
+  };
+}
+
+export async function handleSearch(flags: SearchFlags, deps: SearchDeps = {}): Promise<void> {
+  const {
+    loadCfg = loadConfig,
+    createRepo = (url, key) => new QdrantRepository(url, key),
+    createEmbeddings = createEmbeddingsAdapter,
+    resolveRepos = resolveScopeRepos,
+  } = deps;
+
+  const config = await loadCfg().catch((err: unknown) => {
+    if (
+      err instanceof MemoError &&
+      (err.code === 'CONFIG_NOT_FOUND' || err.code === 'CONFIG_INVALID')
+    ) {
+      return null;
+    }
+    throw err;
+  });
+
+  const repo = flags.repo ?? config?.repo;
+  if (!repo) {
+    throw new MemoError(
+      'REPO_CONTEXT_UNRESOLVED',
+      'Could not resolve repo context. Provide --repo or run `memo setup init`.',
+    );
+  }
+
+  const scope = parseScope(flags.scope, config);
+  const org = flags.org ?? config?.org;
+  const tags = parseCsv(flags.tags);
+  const entryTypes = parseCsv(flags.entryType);
+  const sources = parseCsv(flags.source);
+  const limit = parseLimit(flags.limit);
+
+  const resolvedRepos = resolveRepos({ repo, scope, config });
+  const filters = buildSearchFilters({
+    repo,
+    scope,
+    relatedRepos: resolvedRepos.filter((candidate) => candidate !== repo),
+    org,
+    tags,
+    entryTypes,
+    sources,
+  });
+
+  const responseFilters: SearchResponseFilters = {
+    scope,
+    repo,
+    ...(org ? { org } : {}),
+    ...(tags.length > 0 ? { tags } : {}),
+    ...(entryTypes.length > 0 ? { entry_type: entryTypes } : {}),
+    ...(sources.length > 0 ? { source: sources } : {}),
+    limit,
+  };
+
+  const repoUrl = process.env['QDRANT_URL'];
+  const repoKey = process.env['QDRANT_API_KEY'];
+  const qdrant = createRepo(repoUrl, repoKey);
+  const embeddings = createEmbeddings();
+
+  await qdrant.ensureCollection();
+
+  const vector = await embeddings.embed(buildSearchVectorInput(flags.query, tags));
+  const results = await qdrant.search(vector, filters, limit);
+  const jsonResults = results.map(toJsonResult);
+
+  if (flags.json) {
+    output.result(
+      {
+        query: flags.query,
+        filters: responseFilters,
+        results: jsonResults,
+        count: jsonResults.length,
+        ...(jsonResults.length === 0
+          ? { message: 'No results found for the requested scope and filters.' }
+          : {}),
+      },
+      { json: true },
+    );
+    return;
+  }
+
+  if (results.length === 0) {
+    output.searchEmpty(flags.query, buildActiveFilters(responseFilters, resolvedRepos));
+    return;
+  }
+
+  output.searchResults(
+    results.map((result) => ({
+      id: result.id,
+      similarity: result.score,
+      ...(result.payload ?? {}),
+    })),
+  );
+}
+
+const search = new Command('search')
+  .description('Search for stored decisions using semantic matching with exact pre-filters')
+  .argument('<query>', 'natural language query')
+  .option('--scope <scope>', 'repo|related (default: config or repo)')
+  .option('--repo <name>', 'repository name (overrides config)')
+  .option('--org <name>', 'organization name (overrides config)')
+  .option('--tags <csv>', 'comma-separated tags to require on every result')
+  .option('--entry-type <csv>', 'comma-separated entry types to include')
+  .option('--source <csv>', 'comma-separated sources to include')
+  .option('--limit <n>', 'maximum number of results', '10')
+  .option('--json', 'output as JSON')
+  .action(async (query: string, opts: Record<string, unknown>) => {
+    await handleSearch({
+      query,
+      scope: opts['scope'] as string | undefined,
+      repo: opts['repo'] as string | undefined,
+      org: opts['org'] as string | undefined,
+      tags: opts['tags'] as string | undefined,
+      entryType: opts['entryType'] as string | undefined,
+      source: opts['source'] as string | undefined,
+      limit: opts['limit'] as string | undefined,
+      json: opts['json'] as boolean | undefined,
+    });
+  });
+
+export default search;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import setup from './commands/setup.js';
+import search from './commands/search.js';
 import write from './commands/write.js';
 import { MemoError } from './lib/errors.js';
 
@@ -21,7 +22,7 @@ program
 
 program.addCommand(setup);
 program.addCommand(write);
-// program.addCommand(search);  // S-005
+program.addCommand(search);
 // program.addCommand(list);    // S-006
 
 program.parseAsync(process.argv).catch((err: unknown) => {

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -2,6 +2,41 @@ import chalk from 'chalk';
 import ora from 'ora';
 import type { Ora } from 'ora';
 
+export interface SearchHumanResult {
+  id: string | number;
+  similarity: number;
+  repo?: string;
+  rationale?: string;
+  entry_type?: string;
+  source?: string;
+  org?: string;
+  tags?: string[];
+  story?: string;
+  commit?: string;
+  timestamp_utc?: string;
+}
+
+function toLead(text?: string): string {
+  if (!text) return 'No rationale provided.';
+  const singleLine = text.replace(/\s+/g, ' ').trim();
+  if (singleLine.length <= 140) return singleLine;
+  return `${singleLine.slice(0, 137)}...`;
+}
+
+function renderMetadata(result: SearchHumanResult): string {
+  const parts = [
+    result.org ? `org:${result.org}` : null,
+    result.entry_type ? `type:${result.entry_type}` : null,
+    result.source ? `source:${result.source}` : null,
+    result.story ? `story:${result.story}` : null,
+    result.commit ? `commit:${result.commit}` : null,
+    result.timestamp_utc ? `at:${result.timestamp_utc}` : null,
+    result.tags && result.tags.length > 0 ? `tags:${result.tags.join(', ')}` : null,
+  ].filter((value): value is string => value !== null);
+
+  return parts.join('  ');
+}
+
 export const output = {
   result(data: unknown, opts?: { json?: boolean }): void {
     if (opts?.json) {
@@ -31,5 +66,34 @@ export const output = {
 
   spinner(text: string): Ora {
     return ora({ text, isEnabled: process.stdout.isTTY });
+  },
+
+  searchResults(results: SearchHumanResult[]): void {
+    for (const result of results) {
+      const score = `${String(Math.round(result.similarity * 100))}%`;
+      const repoLabel = result.repo ?? 'unknown-repo';
+      const metadata = renderMetadata(result);
+
+      process.stdout.write(
+        `${chalk.cyan(repoLabel)}  ${chalk.gray(score)}  ${chalk.bold(toLead(result.rationale))}\n`,
+      );
+
+      if (metadata.length > 0) {
+        process.stdout.write(`${chalk.gray(metadata)}\n`);
+      }
+
+      process.stdout.write(`${chalk.gray(`id:${String(result.id)}`)}\n\n`);
+    }
+  },
+
+  searchEmpty(query: string, activeFilters: string[]): void {
+    process.stdout.write(`${chalk.yellow('No results found.')}\n`);
+    process.stdout.write(`${chalk.gray(`query: ${query}`)}\n`);
+    process.stdout.write(
+      `${chalk.gray(`filters: ${activeFilters.length > 0 ? activeFilters.join(' | ') : 'none'}`)}\n`,
+    );
+    process.stdout.write(
+      chalk.gray('tip: broaden the query, remove tags, or switch to --scope related') + '\n',
+    );
   },
 };

--- a/src/lib/qdrant.ts
+++ b/src/lib/qdrant.ts
@@ -1,7 +1,7 @@
 import { QdrantClient } from '@qdrant/js-client-rest';
 import type { Schemas } from '@qdrant/js-client-rest';
 
-type QdrantFilter = Schemas['SearchRequest']['filter'];
+export type QdrantFilter = Schemas['SearchRequest']['filter'];
 import { MemoError } from './errors.js';
 import { withRetry } from './retry.js';
 import { debugLog } from './debug.js';

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -1,2 +1,16 @@
-// TODO: Implement in S-005 — Related-repo resolution helper
-export {};
+import type { MemoConfig } from '../types/config.js';
+
+export interface ResolveScopeReposInput {
+  repo: string;
+  scope: 'repo' | 'related';
+  config?: MemoConfig | null;
+}
+
+export function resolveScopeRepos(input: ResolveScopeReposInput): string[] {
+  if (input.scope !== 'related') {
+    return [input.repo];
+  }
+
+  const relatedRepos = input.config?.relates_to ?? [];
+  return [...new Set([input.repo, ...relatedRepos])];
+}

--- a/src/lib/search-filters.ts
+++ b/src/lib/search-filters.ts
@@ -1,0 +1,59 @@
+import type { QdrantFilter } from './qdrant.js';
+
+export interface BuildSearchFiltersInput {
+  repo: string;
+  scope: 'repo' | 'related';
+  relatedRepos?: string[];
+  org?: string;
+  tags?: string[];
+  entryTypes?: string[];
+  sources?: string[];
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.length > 0))];
+}
+
+function buildAnyMatch(key: string, values: string[]): { key: string; match: { any: string[] } } {
+  return { key, match: { any: values } };
+}
+
+export function buildSearchFilters(input: BuildSearchFiltersInput): QdrantFilter {
+  const must: Record<string, unknown>[] = [];
+  const should: Record<string, unknown>[] = [];
+
+  if (input.scope === 'related') {
+    for (const repo of unique([input.repo, ...(input.relatedRepos ?? [])])) {
+      should.push({ key: 'repo', match: { value: repo } });
+    }
+  } else {
+    must.push({ key: 'repo', match: { value: input.repo } });
+  }
+
+  if (input.org) {
+    must.push({ key: 'org', match: { value: input.org } });
+  }
+
+  for (const tag of unique(input.tags ?? [])) {
+    must.push({ key: 'tags', match: { value: tag } });
+  }
+
+  const entryTypes = unique(input.entryTypes ?? []);
+  if (entryTypes.length === 1) {
+    must.push({ key: 'entry_type', match: { value: entryTypes[0] } });
+  } else if (entryTypes.length > 1) {
+    must.push(buildAnyMatch('entry_type', entryTypes));
+  }
+
+  const sources = unique(input.sources ?? []);
+  if (sources.length === 1) {
+    must.push({ key: 'source', match: { value: sources[0] } });
+  } else if (sources.length > 1) {
+    must.push(buildAnyMatch('source', sources));
+  }
+
+  return {
+    ...(must.length > 0 ? { must } : {}),
+    ...(should.length > 0 ? { should } : {}),
+  };
+}

--- a/tests/integration/commands/search.test.ts
+++ b/tests/integration/commands/search.test.ts
@@ -1,0 +1,130 @@
+import { handleSearch } from '../../../src/commands/search.js';
+import type { SearchDeps } from '../../../src/commands/search.js';
+
+const mockQdrant = {
+  ensureCollection: jest.fn().mockResolvedValue(undefined),
+  search: jest.fn(),
+};
+
+const mockEmbeddings = {
+  embed: jest.fn().mockResolvedValue(new Array<number>(1536).fill(0.15)),
+  dimensions: 1536,
+};
+
+const mockConfig = {
+  schema_version: '1' as const,
+  repo: 'memo-cli',
+  org: 'llipe',
+  domain: 'developer-tools',
+  relates_to: ['platform-docs', 'agent-sdk'],
+  defaults: { source: 'agent' as const, search_scope: 'related' as const },
+};
+
+let stdoutData = '';
+
+beforeEach(() => {
+  stdoutData = '';
+  jest.spyOn(process.stdout, 'write').mockImplementation((data: any) => {
+    stdoutData += String(data);
+    return true;
+  });
+  jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('search integration', () => {
+  const deps: SearchDeps = {
+    loadCfg: jest.fn().mockResolvedValue(mockConfig),
+    createRepo: () => mockQdrant as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    createEmbeddings: () => mockEmbeddings as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  };
+
+  it('returns the JSON contract with payload fields plus similarity', async () => {
+    mockQdrant.search.mockResolvedValueOnce([
+      {
+        id: 'entry-1',
+        score: 0.8129,
+        payload: {
+          repo: 'memo-cli',
+          org: 'llipe',
+          domain: 'developer-tools',
+          rationale: 'Entries are persisted through QdrantRepository after schema validation.',
+          tags: ['qdrant', 'write-flow'],
+          entry_type: 'decision',
+          source: 'agent',
+          confidence: 'high',
+          timestamp_utc: '2026-04-10T14:25:02.431Z',
+        },
+      },
+    ]);
+
+    await handleSearch({ query: 'persist decisions', json: true }, deps);
+
+    const result = JSON.parse(stdoutData) as Record<string, unknown>;
+    expect(result['query']).toBe('persist decisions');
+    expect(result['count']).toBe(1);
+    expect((result['filters'] as Record<string, unknown>)['scope']).toBe('related');
+    expect((result['results'] as Array<Record<string, unknown>>)[0]).toMatchObject({
+      id: 'entry-1',
+      repo: 'memo-cli',
+      similarity: 0.8129,
+    });
+  });
+
+  it('returns success JSON for empty results', async () => {
+    mockQdrant.search.mockResolvedValueOnce([]);
+
+    await handleSearch({ query: 'missing decision', json: true }, deps);
+
+    const result = JSON.parse(stdoutData) as Record<string, unknown>;
+    expect(result['count']).toBe(0);
+    expect(result['message']).toBe('No results found for the requested scope and filters.');
+    expect(result['results']).toEqual([]);
+  });
+
+  it('expands related scope using relates_to repositories from config', async () => {
+    mockQdrant.search.mockResolvedValueOnce([]);
+
+    await handleSearch({ query: 'cross repo decision' }, deps);
+
+    expect(mockQdrant.search).toHaveBeenCalledWith(
+      expect.any(Array),
+      {
+        must: [{ key: 'org', match: { value: 'llipe' } }],
+        should: [
+          { key: 'repo', match: { value: 'memo-cli' } },
+          { key: 'repo', match: { value: 'platform-docs' } },
+          { key: 'repo', match: { value: 'agent-sdk' } },
+        ],
+      },
+      10,
+    );
+  });
+
+  it('renders human-readable result output', async () => {
+    mockQdrant.search.mockResolvedValueOnce([
+      {
+        id: 'entry-1',
+        score: 0.91,
+        payload: {
+          repo: 'memo-cli',
+          org: 'llipe',
+          rationale: 'Use related scope to expand repo search coverage.',
+          entry_type: 'decision',
+          source: 'agent',
+          tags: ['search', 'scope'],
+        },
+      },
+    ]);
+
+    await handleSearch({ query: 'scope expansion' }, deps);
+
+    expect(stdoutData).toContain('memo-cli');
+    expect(stdoutData).toContain('91%');
+    expect(stdoutData).toContain('Use related scope to expand repo search coverage.');
+  });
+});

--- a/tests/unit/commands/search.test.ts
+++ b/tests/unit/commands/search.test.ts
@@ -1,0 +1,109 @@
+import { buildSearchVectorInput, handleSearch } from '../../../src/commands/search.js';
+import type { SearchDeps } from '../../../src/commands/search.js';
+import { MemoError } from '../../../src/lib/errors.js';
+
+const mockQdrant = {
+  ensureCollection: jest.fn().mockResolvedValue(undefined),
+  search: jest.fn().mockResolvedValue([]),
+};
+
+const mockEmbeddings = {
+  embed: jest.fn().mockResolvedValue(new Array<number>(1536).fill(0.25)),
+  dimensions: 1536,
+};
+
+const mockConfig = {
+  schema_version: '1' as const,
+  repo: 'memo-cli',
+  org: 'llipe',
+  domain: 'developer-tools',
+  relates_to: ['platform-docs'],
+  defaults: { source: 'agent' as const, search_scope: 'repo' as const },
+};
+
+let stdoutData = '';
+
+beforeEach(() => {
+  stdoutData = '';
+  jest.spyOn(process.stdout, 'write').mockImplementation((data: any) => {
+    stdoutData += String(data);
+    return true;
+  });
+  jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  jest.clearAllMocks();
+  mockQdrant.search.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('buildSearchVectorInput', () => {
+  it('returns query plus normalized tag terms when tags are present', () => {
+    expect(buildSearchVectorInput('persist decisions', ['qdrant', 'search'])).toBe(
+      'persist decisions qdrant search',
+    );
+  });
+
+  it('returns the raw query when no tags are present', () => {
+    expect(buildSearchVectorInput('persist decisions', [])).toBe('persist decisions');
+  });
+});
+
+describe('handleSearch', () => {
+  const deps: SearchDeps = {
+    loadCfg: jest.fn().mockResolvedValue(mockConfig),
+    createRepo: () => mockQdrant as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    createEmbeddings: () => mockEmbeddings as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  };
+
+  it('embeds query plus tags and calls search with the built filter', async () => {
+    await handleSearch(
+      {
+        query: 'persist decisions',
+        tags: 'qdrant,search',
+        entryType: 'decision,structure',
+        source: 'agent,manual',
+        limit: '3',
+      },
+      deps,
+    );
+
+    expect(mockQdrant.ensureCollection).toHaveBeenCalled();
+    expect(mockEmbeddings.embed).toHaveBeenCalledWith('persist decisions qdrant search');
+    expect(mockQdrant.search).toHaveBeenCalledWith(
+      expect.any(Array),
+      {
+        must: [
+          { key: 'repo', match: { value: 'memo-cli' } },
+          { key: 'org', match: { value: 'llipe' } },
+          { key: 'tags', match: { value: 'qdrant' } },
+          { key: 'tags', match: { value: 'search' } },
+          { key: 'entry_type', match: { any: ['decision', 'structure'] } },
+          { key: 'source', match: { any: ['agent', 'manual'] } },
+        ],
+      },
+      3,
+    );
+  });
+
+  it('throws when repo context cannot be resolved', async () => {
+    const missingContextDeps: SearchDeps = {
+      ...deps,
+      loadCfg: jest.fn().mockRejectedValue(new MemoError('CONFIG_NOT_FOUND', 'not found')),
+    };
+
+    await expect(
+      handleSearch({ query: 'persist decisions' }, missingContextDeps),
+    ).rejects.toMatchObject({
+      code: 'REPO_CONTEXT_UNRESOLVED',
+    });
+  });
+
+  it('renders an empty-state message in human mode', async () => {
+    await handleSearch({ query: 'missing decision' }, deps);
+
+    expect(stdoutData).toContain('No results found.');
+    expect(stdoutData).toContain('tip: broaden the query');
+  });
+});

--- a/tests/unit/lib/search-filters.test.ts
+++ b/tests/unit/lib/search-filters.test.ts
@@ -1,0 +1,71 @@
+import { buildSearchFilters } from '../../../src/lib/search-filters.js';
+
+describe('buildSearchFilters', () => {
+  it('builds repo-scoped filters with multi-tag AND semantics', () => {
+    const filter = buildSearchFilters({
+      repo: 'memo-cli',
+      scope: 'repo',
+      tags: ['qdrant', 'search'],
+    });
+
+    expect(filter).toEqual({
+      must: [
+        { key: 'repo', match: { value: 'memo-cli' } },
+        { key: 'tags', match: { value: 'qdrant' } },
+        { key: 'tags', match: { value: 'search' } },
+      ],
+    });
+  });
+
+  it('builds related scope filters with should repo clauses', () => {
+    const filter = buildSearchFilters({
+      repo: 'memo-cli',
+      scope: 'related',
+      relatedRepos: ['platform-docs', 'agent-sdk'],
+    });
+
+    expect(filter).toEqual({
+      should: [
+        { key: 'repo', match: { value: 'memo-cli' } },
+        { key: 'repo', match: { value: 'platform-docs' } },
+        { key: 'repo', match: { value: 'agent-sdk' } },
+      ],
+    });
+  });
+
+  it('uses match-any for multi-value entry_type and source filters', () => {
+    const filter = buildSearchFilters({
+      repo: 'memo-cli',
+      scope: 'repo',
+      entryTypes: ['decision', 'structure'],
+      sources: ['agent', 'manual'],
+    });
+
+    expect(filter).toEqual({
+      must: [
+        { key: 'repo', match: { value: 'memo-cli' } },
+        { key: 'entry_type', match: { any: ['decision', 'structure'] } },
+        { key: 'source', match: { any: ['agent', 'manual'] } },
+      ],
+    });
+  });
+
+  it('includes org when provided', () => {
+    const filter = buildSearchFilters({
+      repo: 'memo-cli',
+      scope: 'repo',
+      org: 'llipe',
+      entryTypes: ['decision'],
+      sources: ['agent'],
+    });
+
+    expect(filter).toEqual({
+      must: [
+        { key: 'repo', match: { value: 'memo-cli' } },
+        { key: 'org', match: { value: 'llipe' } },
+        { key: 'entry_type', match: { value: 'decision' } },
+        { key: 'source', match: { value: 'agent' } },
+      ],
+    });
+  });
+});

--- a/workstream/tasks-prd-001-mvp-plan.md
+++ b/workstream/tasks-prd-001-mvp-plan.md
@@ -16,6 +16,7 @@
 - `src/lib/config.ts` — Config loader, writer, validator
 - `src/lib/output.ts` — Human/JSON output formatter, interactive prompts
 - `src/lib/qdrant.ts` — `QdrantRepository` (bootstrap, upsert, search, scroll)
+- `src/lib/search-filters.ts` — Search pre-filter builder for repo/scope/tag semantics
 - `src/lib/embeddings.ts` — `EmbeddingsAdapter` interface + factory
 - `src/lib/retry.ts` — Retry with exponential backoff
 - `src/lib/registry.ts` — Related-repo resolution helper
@@ -28,6 +29,7 @@
 - `.env.example` — Environment variable documentation
 - `.gitignore` — Ignore rules
 - `README.md` — Setup instructions + Quick Start
+- `scripts/run-jest.mjs` — Jest argument-forwarding wrapper for scoped test commands
 - `docs/bootstrap-guide.md` — Bootstrap prompt documentation
 - `scripts/validate-bootstrap.ts` — Bootstrap JSON validation script
 - `tests/unit/lib/errors.test.ts`
@@ -36,6 +38,8 @@
 - `tests/unit/lib/qdrant.test.ts`
 - `tests/unit/lib/dedupe.test.ts`
 - `tests/unit/lib/search-filters.test.ts`
+- `tests/unit/commands/search.test.ts`
+- `tests/integration/commands/search.test.ts`
 - `tests/unit/lib/list-filters.test.ts`
 - `tests/unit/adapters/openai-embeddings.test.ts`
 - `tests/unit/commands/write.test.ts`
@@ -140,24 +144,24 @@
   - [x] 4.21 Verify Acceptance Criterion: tags 2–5 enforced, rationale ≤5000 chars
   - [x] 4.22 Run tests: `pnpm run test -- --testPathPattern="write|dedupe"`
 
-- [ ] 5.0 Implement Story S-005 — Issue #5 - https://github.com/llipe/memo-cli/issues/5: `memo search` — Semantic Search with Pre-filters
-  - [ ] 5.1 Implement `buildSearchFilters()` in `src/lib/search-filters.ts` — single repo, multi-tag AND (`must`), related scope (`should`), entry_type filter, source filter
-  - [ ] 5.2 Implement vector composition logic — `embed(query + " " + tags.join(" "))` when tags provided
-  - [ ] 5.3 Implement related-scope repo list resolution in `src/lib/registry.ts` — reads config `relates_to` array
-  - [ ] 5.4 Implement `QdrantRepository.search()` method (if not already complete from S-003)
-  - [ ] 5.5 Implement search command orchestration in `src/commands/search.ts`: parse flags → resolve context → build filters → embed query → search → format output
-  - [ ] 5.6 Implement human output for search results — `cyan` labels, `bold` rationale lead, `gray` metadata, similarity as `Math.round(score * 100)%`
-  - [ ] 5.7 Implement human empty-results display — show active filters + broadening tip
-  - [ ] 5.8 Implement `--json` output: `query`, `filters`, `results` array (all payload + `similarity`), `count`, `message` on empty
-  - [ ] 5.9 Implement auto-bootstrap on first search
-  - [ ] 5.10 Register `memo search` in `src/index.ts` with all flag definitions
-  - [ ] 5.11 Write unit tests: `tests/unit/lib/search-filters.test.ts` — filter builder for all flag combos
-  - [ ] 5.12 Write unit tests: `tests/unit/commands/search.test.ts` — vector composition, command orchestration
-  - [ ] 5.13 Write integration tests: `tests/integration/commands/search.test.ts` — search with mock results, empty results, `--json` contract, related scope expansion
-  - [ ] 5.14 Verify Acceptance Criterion: multi-tag AND semantics
-  - [ ] 5.15 Verify Acceptance Criterion: `--scope related` expands to `relates_to` repos
-  - [ ] 5.16 Verify Acceptance Criterion: empty results return exit 0 with empty array
-  - [ ] 5.17 Run tests: `pnpm run test -- --testPathPattern="search"`
+- [x] 5.0 Implement Story S-005 — Issue #5 - https://github.com/llipe/memo-cli/issues/5: `memo search` — Semantic Search with Pre-filters
+  - [x] 5.1 Implement `buildSearchFilters()` in `src/lib/search-filters.ts` — single repo, multi-tag AND (`must`), related scope (`should`), entry_type filter, source filter
+  - [x] 5.2 Implement vector composition logic — `embed(query + " " + tags.join(" "))` when tags provided
+  - [x] 5.3 Implement related-scope repo list resolution in `src/lib/registry.ts` — reads config `relates_to` array
+  - [x] 5.4 Implement `QdrantRepository.search()` method (if not already complete from S-003)
+  - [x] 5.5 Implement search command orchestration in `src/commands/search.ts`: parse flags → resolve context → build filters → embed query → search → format output
+  - [x] 5.6 Implement human output for search results — `cyan` labels, `bold` rationale lead, `gray` metadata, similarity as `Math.round(score * 100)%`
+  - [x] 5.7 Implement human empty-results display — show active filters + broadening tip
+  - [x] 5.8 Implement `--json` output: `query`, `filters`, `results` array (all payload + `similarity`), `count`, `message` on empty
+  - [x] 5.9 Implement auto-bootstrap on first search
+  - [x] 5.10 Register `memo search` in `src/index.ts` with all flag definitions
+  - [x] 5.11 Write unit tests: `tests/unit/lib/search-filters.test.ts` — filter builder for all flag combos
+  - [x] 5.12 Write unit tests: `tests/unit/commands/search.test.ts` — vector composition, command orchestration
+  - [x] 5.13 Write integration tests: `tests/integration/commands/search.test.ts` — search with mock results, empty results, `--json` contract, related scope expansion
+  - [x] 5.14 Verify Acceptance Criterion: multi-tag AND semantics
+  - [x] 5.15 Verify Acceptance Criterion: `--scope related` expands to `relates_to` repos
+  - [x] 5.16 Verify Acceptance Criterion: empty results return exit 0 with empty array
+  - [x] 5.17 Run tests: `pnpm run test -- --testPathPattern="search"`
 
 - [ ] 6.0 Implement Story S-006 — Issue #6 - https://github.com/llipe/memo-cli/issues/6: `memo list` — Chronological Entry Listing
   - [ ] 6.1 Implement `QdrantRepository.scroll()` with `order_by: { key: "timestamp_utc", direction: "desc" }` and filter support


### PR DESCRIPTION
## What
Implement Story S-005 for `memo search`, including pre-filter construction, related-scope repo expansion, CLI orchestration, human/JSON output, and search-focused test coverage.

## Why
Closes #5

## How
- add `buildSearchFilters()` with repo scope, related scope, multi-tag AND, and multi-value `entry_type` / `source` handling
- add related-repo resolution from local config and implement the search command orchestration with auto-bootstrap
- format human search output and empty states, add JSON response shaping, and add a Jest wrapper so `pnpm run test -- --testPathPattern=search` works as required

## Testing
- [x] `pnpm run test -- --testPathPattern=search`
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`

## Checklist
- [x] Tests pass
- [x] Docs updated (if applicable)
- [x] No unrelated changes