### PR TITLE
feat: implement issue 6

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,2 +1,211 @@
-// TODO: Implement in S-006 — memo list
-export {};
+import { Command } from 'commander';
+import { loadConfig } from '../lib/config.js';
+import { MemoError } from '../lib/errors.js';
+import { buildListFilters, normalizeListDateRange } from '../lib/list-filters.js';
+import { output } from '../lib/output.js';
+import { QdrantRepository } from '../lib/qdrant.js';
+import { resolveScopeRepos } from '../lib/registry.js';
+import type { ScrollResult } from '../lib/qdrant.js';
+import type { MemoConfig } from '../types/config.js';
+
+export interface ListFlags {
+  scope?: string;
+  repo?: string;
+  org?: string;
+  entryType?: string;
+  source?: string;
+  from?: string;
+  to?: string;
+  limit?: string | number;
+  json?: boolean;
+}
+
+export interface ListDeps {
+  loadCfg?: typeof loadConfig;
+  createRepo?: (url?: string, key?: string) => QdrantRepository;
+  resolveRepos?: typeof resolveScopeRepos;
+}
+
+export interface ListResponseFilters {
+  scope: 'repo' | 'related';
+  repo: string;
+  org?: string;
+  entry_type?: string[];
+  source?: string[];
+  from?: string;
+  to?: string;
+  limit: number;
+}
+
+function parseCsv(value?: string): string[] {
+  if (!value) return [];
+  return [
+    ...new Set(
+      value
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0),
+    ),
+  ];
+}
+
+function parseScope(value: string | undefined, config?: MemoConfig | null): 'repo' | 'related' {
+  const scope = value ?? config?.defaults.search_scope ?? 'repo';
+  if (scope !== 'repo' && scope !== 'related') {
+    throw new MemoError(
+      'VALIDATION_FAILED',
+      `Invalid --scope value "${scope}". Use repo or related.`,
+    );
+  }
+  return scope;
+}
+
+function parseLimit(value: string | number | undefined): number {
+  if (value === undefined) return 20;
+  const parsed = typeof value === 'number' ? value : Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new MemoError('VALIDATION_FAILED', '--limit must be a positive integer.');
+  }
+  return parsed;
+}
+
+function buildActiveFilters(filters: ListResponseFilters, repoSet: string[]): string[] {
+  const values = [`scope:${filters.scope}`, `repo:${repoSet.join(',')}`];
+  if (filters.org) values.push(`org:${filters.org}`);
+  if (filters.entry_type && filters.entry_type.length > 0) {
+    values.push(`entry_type:${filters.entry_type.join(',')}`);
+  }
+  if (filters.source && filters.source.length > 0) {
+    values.push(`source:${filters.source.join(',')}`);
+  }
+  if (filters.from) values.push(`from:${filters.from}`);
+  if (filters.to) values.push(`to:${filters.to}`);
+  values.push(`limit:${String(filters.limit)}`);
+  return values;
+}
+
+function toJsonResult(result: ScrollResult): Record<string, unknown> {
+  return {
+    id: result.id,
+    ...(result.payload ?? {}),
+  };
+}
+
+export async function handleList(flags: ListFlags, deps: ListDeps = {}): Promise<void> {
+  const {
+    loadCfg = loadConfig,
+    createRepo = (url, key) => new QdrantRepository(url, key),
+    resolveRepos = resolveScopeRepos,
+  } = deps;
+
+  const config = await loadCfg().catch((err: unknown) => {
+    if (
+      err instanceof MemoError &&
+      (err.code === 'CONFIG_NOT_FOUND' || err.code === 'CONFIG_INVALID')
+    ) {
+      return null;
+    }
+    throw err;
+  });
+
+  const repo = flags.repo ?? config?.repo;
+  if (!repo) {
+    throw new MemoError(
+      'REPO_CONTEXT_UNRESOLVED',
+      'Could not resolve repo context. Provide --repo or run `memo setup init`.',
+    );
+  }
+
+  const scope = parseScope(flags.scope, config);
+  const org = flags.org ?? config?.org;
+  const entryTypes = parseCsv(flags.entryType);
+  const sources = parseCsv(flags.source);
+  const limit = parseLimit(flags.limit);
+  const { from, to } = normalizeListDateRange({ from: flags.from, to: flags.to });
+
+  const resolvedRepos = resolveRepos({ repo, scope, config });
+  const filters = buildListFilters({
+    repo,
+    scope,
+    relatedRepos: resolvedRepos.filter((candidate) => candidate !== repo),
+    org,
+    entryTypes,
+    sources,
+    from,
+    to,
+  });
+
+  const responseFilters: ListResponseFilters = {
+    scope,
+    repo,
+    ...(org ? { org } : {}),
+    ...(entryTypes.length > 0 ? { entry_type: entryTypes } : {}),
+    ...(sources.length > 0 ? { source: sources } : {}),
+    ...(from ? { from } : {}),
+    ...(to ? { to } : {}),
+    limit,
+  };
+
+  const repoUrl = process.env['QDRANT_URL'];
+  const repoKey = process.env['QDRANT_API_KEY'];
+  const qdrant = createRepo(repoUrl, repoKey);
+
+  await qdrant.ensureCollection();
+
+  const results = await qdrant.scroll(filters, limit);
+  const jsonResults = results.map(toJsonResult);
+
+  if (flags.json) {
+    output.result(
+      {
+        filters: responseFilters,
+        results: jsonResults,
+        count: jsonResults.length,
+        ...(jsonResults.length === 0
+          ? { message: 'No entries found for the requested scope and filters.' }
+          : {}),
+      },
+      { json: true },
+    );
+    return;
+  }
+
+  if (results.length === 0) {
+    output.listEmpty(buildActiveFilters(responseFilters, resolvedRepos));
+    return;
+  }
+
+  output.listResults(
+    results.map((result) => ({
+      id: result.id,
+      ...(result.payload ?? {}),
+    })),
+  );
+}
+
+const list = new Command('list')
+  .description('List recent memo entries in reverse chronological order')
+  .option('--scope <scope>', 'repo|related (default: config or repo)')
+  .option('--repo <name>', 'repository name (overrides config)')
+  .option('--org <name>', 'organization name (overrides config)')
+  .option('--entry-type <csv>', 'comma-separated entry types to include')
+  .option('--source <csv>', 'comma-separated sources to include')
+  .option('--from <iso>', 'inclusive ISO 8601 lower bound for timestamp_utc')
+  .option('--to <iso>', 'inclusive ISO 8601 upper bound for timestamp_utc')
+  .option('--limit <n>', 'maximum number of results', '20')
+  .option('--json', 'output as JSON')
+  .action(async (opts: Record<string, unknown>) => {
+    await handleList({
+      scope: opts['scope'] as string | undefined,
+      repo: opts['repo'] as string | undefined,
+      org: opts['org'] as string | undefined,
+      entryType: opts['entryType'] as string | undefined,
+      source: opts['source'] as string | undefined,
+      from: opts['from'] as string | undefined,
+      to: opts['to'] as string | undefined,
+      limit: opts['limit'] as string | undefined,
+      json: opts['json'] as boolean | undefined,
+    });
+  });
+
+export default list;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { dirname, join } from 'node:path';
 import setup from './commands/setup.js';
 import search from './commands/search.js';
 import write from './commands/write.js';
+import list from './commands/list.js';
 import { MemoError } from './lib/errors.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -23,7 +24,7 @@ program
 program.addCommand(setup);
 program.addCommand(write);
 program.addCommand(search);
-// program.addCommand(list);    // S-006
+program.addCommand(list);
 
 program.parseAsync(process.argv).catch((err: unknown) => {
   const memoErr =

--- a/src/lib/list-filters.ts
+++ b/src/lib/list-filters.ts
@@ -1,0 +1,122 @@
+import { MemoError } from './errors.js';
+import type { QdrantFilter } from './qdrant.js';
+
+export interface BuildListFiltersInput {
+  repo: string;
+  scope: 'repo' | 'related';
+  relatedRepos?: string[];
+  org?: string;
+  entryTypes?: string[];
+  sources?: string[];
+  from?: string;
+  to?: string;
+}
+
+interface MatchCondition {
+  key: string;
+  match: { value: string } | { any: string[] };
+}
+
+interface RangeCondition {
+  key: string;
+  range: { gte?: string; lte?: string };
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.length > 0))];
+}
+
+function buildAnyMatch(key: string, values: string[]): MatchCondition {
+  return { key, match: { any: values } };
+}
+
+function normalizeIsoBoundary(value: string, boundary: 'from' | 'to'): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new MemoError('VALIDATION_FAILED', `--${boundary} must not be empty.`);
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    return boundary === 'from' ? `${trimmed}T00:00:00.000Z` : `${trimmed}T23:59:59.999Z`;
+  }
+
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new MemoError(
+      'VALIDATION_FAILED',
+      `--${boundary} must be a valid ISO 8601 date string. Received "${value}".`,
+    );
+  }
+
+  return parsed.toISOString();
+}
+
+export function normalizeListDateRange(input: { from?: string; to?: string }): {
+  from?: string;
+  to?: string;
+} {
+  const from = input.from ? normalizeIsoBoundary(input.from, 'from') : undefined;
+  const to = input.to ? normalizeIsoBoundary(input.to, 'to') : undefined;
+
+  if (from && to && from > to) {
+    throw new MemoError('VALIDATION_FAILED', '--from must be earlier than or equal to --to.');
+  }
+
+  return {
+    ...(from ? { from } : {}),
+    ...(to ? { to } : {}),
+  };
+}
+
+export function buildListFilters(input: BuildListFiltersInput): QdrantFilter {
+  const must: (MatchCondition | RangeCondition)[] = [];
+  const should: MatchCondition[] = [];
+
+  if (input.scope === 'related') {
+    for (const repo of unique([input.repo, ...(input.relatedRepos ?? [])])) {
+      should.push({ key: 'repo', match: { value: repo } });
+    }
+  } else {
+    must.push({ key: 'repo', match: { value: input.repo } });
+  }
+
+  if (input.org) {
+    must.push({ key: 'org', match: { value: input.org } });
+  }
+
+  const entryTypes = unique(input.entryTypes ?? []);
+  const entryType = entryTypes[0];
+  if (entryTypes.length === 1) {
+    if (entryType) {
+      must.push({ key: 'entry_type', match: { value: entryType } });
+    }
+  } else if (entryTypes.length > 1) {
+    must.push(buildAnyMatch('entry_type', entryTypes));
+  }
+
+  const sources = unique(input.sources ?? []);
+  const source = sources[0];
+  if (sources.length === 1) {
+    if (source) {
+      must.push({ key: 'source', match: { value: source } });
+    }
+  } else if (sources.length > 1) {
+    must.push(buildAnyMatch('source', sources));
+  }
+
+  const range = normalizeListDateRange({ from: input.from, to: input.to });
+  if (range.from || range.to) {
+    must.push({
+      key: 'timestamp_utc',
+      range: {
+        ...(range.from ? { gte: range.from } : {}),
+        ...(range.to ? { lte: range.to } : {}),
+      },
+    });
+  }
+
+  return {
+    ...(must.length > 0 ? { must } : {}),
+    ...(should.length > 0 ? { should } : {}),
+  };
+}

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -16,6 +16,19 @@ export interface SearchHumanResult {
   timestamp_utc?: string;
 }
 
+export interface ListHumanResult {
+  id: string | number;
+  repo?: string;
+  rationale?: string;
+  entry_type?: string;
+  source?: string;
+  org?: string;
+  tags?: string[];
+  story?: string;
+  commit?: string;
+  timestamp_utc?: string;
+}
+
 function toLead(text?: string): string {
   if (!text) return 'No rationale provided.';
   const singleLine = text.replace(/\s+/g, ' ').trim();
@@ -31,6 +44,19 @@ function renderMetadata(result: SearchHumanResult): string {
     result.story ? `story:${result.story}` : null,
     result.commit ? `commit:${result.commit}` : null,
     result.timestamp_utc ? `at:${result.timestamp_utc}` : null,
+    result.tags && result.tags.length > 0 ? `tags:${result.tags.join(', ')}` : null,
+  ].filter((value): value is string => value !== null);
+
+  return parts.join('  ');
+}
+
+function renderListMetadata(result: ListHumanResult): string {
+  const parts = [
+    result.org ? `org:${result.org}` : null,
+    result.entry_type ? `type:${result.entry_type}` : null,
+    result.source ? `source:${result.source}` : null,
+    result.story ? `story:${result.story}` : null,
+    result.commit ? `commit:${result.commit}` : null,
     result.tags && result.tags.length > 0 ? `tags:${result.tags.join(', ')}` : null,
   ].filter((value): value is string => value !== null);
 
@@ -94,6 +120,36 @@ export const output = {
     );
     process.stdout.write(
       chalk.gray('tip: broaden the query, remove tags, or switch to --scope related') + '\n',
+    );
+  },
+
+  listResults(results: ListHumanResult[]): void {
+    process.stdout.write(
+      `${chalk.gray('timestamp_utc')}  ${chalk.gray('repo')}  ${chalk.gray('rationale')}\n`,
+    );
+
+    for (const result of results) {
+      const timestamp = result.timestamp_utc ?? 'unknown-time';
+      const repoLabel = result.repo ?? 'unknown-repo';
+      const metadata = renderListMetadata(result);
+
+      process.stdout.write(
+        `${chalk.gray(timestamp)}  ${chalk.cyan(repoLabel)}  ${chalk.bold(toLead(result.rationale))}\n`,
+      );
+
+      if (metadata.length > 0) {
+        process.stdout.write(`${chalk.gray(metadata)}\n`);
+      }
+
+      process.stdout.write(`${chalk.gray(`id:${String(result.id)}`)}\n\n`);
+    }
+  },
+
+  listEmpty(activeFilters: string[]): void {
+    process.stdout.write(`${chalk.yellow('No entries found.')}\n`);
+    process.stdout.write(`${chalk.gray('count: 0')}\n`);
+    process.stdout.write(
+      `${chalk.gray(`filters: ${activeFilters.length > 0 ? activeFilters.join(' | ') : 'none'}`)}\n`,
     );
   },
 };

--- a/src/lib/qdrant.ts
+++ b/src/lib/qdrant.ts
@@ -26,7 +26,7 @@ const PAYLOAD_INDEXES = [
   { field: 'entry_type', schema: 'keyword' },
   { field: 'source', schema: 'keyword' },
   { field: 'tags', schema: 'keyword' },
-  { field: 'timestamp_utc', schema: 'integer' },
+  { field: 'timestamp_utc', schema: 'datetime' },
   { field: 'commit', schema: 'keyword' },
   { field: 'dedupe_key_sha256', schema: 'keyword' },
 ] as const;
@@ -131,6 +131,7 @@ export class QdrantRepository {
           filter,
           limit,
           with_payload: true,
+          order_by: { key: 'timestamp_utc', direction: 'desc' },
         }),
       );
       return (

--- a/tests/integration/commands/list.test.ts
+++ b/tests/integration/commands/list.test.ts
@@ -1,0 +1,141 @@
+import { handleList } from '../../../src/commands/list.js';
+import type { ListDeps } from '../../../src/commands/list.js';
+
+const mockQdrant = {
+  ensureCollection: jest.fn().mockResolvedValue(undefined),
+  scroll: jest.fn(),
+};
+
+const mockConfig = {
+  schema_version: '1' as const,
+  repo: 'memo-cli',
+  org: 'llipe',
+  domain: 'developer-tools',
+  relates_to: ['platform-docs', 'agent-sdk'],
+  defaults: { source: 'agent' as const, search_scope: 'related' as const },
+};
+
+let stdoutData = '';
+
+beforeEach(() => {
+  stdoutData = '';
+  jest.spyOn(process.stdout, 'write').mockImplementation((data: any) => {
+    stdoutData += String(data);
+    return true;
+  });
+  jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('list integration', () => {
+  const deps: ListDeps = {
+    loadCfg: jest.fn().mockResolvedValue(mockConfig),
+    createRepo: () => mockQdrant as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  };
+
+  it('returns the JSON contract with all payload fields', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([
+      {
+        id: 'entry-1',
+        payload: {
+          id: 'entry-1',
+          repo: 'memo-cli',
+          org: 'llipe',
+          domain: 'developer-tools',
+          rationale: 'List results should preserve every stored payload field in JSON mode.',
+          tags: ['list', 'json'],
+          entry_type: 'decision',
+          source: 'agent',
+          confidence: 'high',
+          timestamp_utc: '2026-04-10T14:25:02.431Z',
+          files_modified: ['src/commands/list.ts'],
+          relates_to: ['platform-docs'],
+          dedupe_key_sha256: 'abc123',
+          dedupe_key_version: 'v1',
+        },
+      },
+    ]);
+
+    await handleList({ json: true }, deps);
+
+    const result = JSON.parse(stdoutData) as Record<string, unknown>;
+    expect((result['filters'] as Record<string, unknown>)['scope']).toBe('related');
+    expect((result['filters'] as Record<string, unknown>)['limit']).toBe(20);
+    expect(result['count']).toBe(1);
+    expect((result['results'] as Array<Record<string, unknown>>)[0]).toMatchObject({
+      id: 'entry-1',
+      repo: 'memo-cli',
+      timestamp_utc: '2026-04-10T14:25:02.431Z',
+      files_modified: ['src/commands/list.ts'],
+      dedupe_key_version: 'v1',
+    });
+  });
+
+  it('returns success JSON for empty results', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([]);
+
+    await handleList(
+      {
+        json: true,
+        from: '2026-01-01',
+        to: '2026-01-31',
+        entryType: 'integration_point',
+        source: 'manual',
+      },
+      deps,
+    );
+
+    const result = JSON.parse(stdoutData) as Record<string, unknown>;
+    expect(result['count']).toBe(0);
+    expect(result['message']).toBe('No entries found for the requested scope and filters.');
+    expect(result['results']).toEqual([]);
+    expect(result['filters']).toEqual({
+      scope: 'related',
+      repo: 'memo-cli',
+      org: 'llipe',
+      entry_type: ['integration_point'],
+      source: ['manual'],
+      from: '2026-01-01T00:00:00.000Z',
+      to: '2026-01-31T23:59:59.999Z',
+      limit: 20,
+    });
+  });
+
+  it('passes normalized from/to filters to the repository', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([]);
+
+    await handleList({ json: true, from: '2026-02-01', to: '2026-02-03' }, deps);
+
+    expect(mockQdrant.scroll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        must: expect.arrayContaining([
+          {
+            key: 'timestamp_utc',
+            range: {
+              gte: '2026-02-01T00:00:00.000Z',
+              lte: '2026-02-03T23:59:59.999Z',
+            },
+          },
+        ]),
+      }),
+      20,
+    );
+  });
+
+  it('passes entry-type filters to the repository', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([]);
+
+    await handleList({ json: true, entryType: 'structure' }, deps);
+
+    expect(mockQdrant.scroll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        must: expect.arrayContaining([{ key: 'entry_type', match: { value: 'structure' } }]),
+      }),
+      20,
+    );
+  });
+});

--- a/tests/unit/commands/list.test.ts
+++ b/tests/unit/commands/list.test.ts
@@ -1,0 +1,105 @@
+import { handleList } from '../../../src/commands/list.js';
+import type { ListDeps } from '../../../src/commands/list.js';
+import { MemoError } from '../../../src/lib/errors.js';
+
+const mockQdrant = {
+  ensureCollection: jest.fn().mockResolvedValue(undefined),
+  scroll: jest.fn().mockResolvedValue([]),
+};
+
+const mockConfig = {
+  schema_version: '1' as const,
+  repo: 'memo-cli',
+  org: 'llipe',
+  domain: 'developer-tools',
+  relates_to: ['platform-docs'],
+  defaults: { source: 'agent' as const, search_scope: 'related' as const },
+};
+
+let stdoutData = '';
+
+beforeEach(() => {
+  stdoutData = '';
+  jest.spyOn(process.stdout, 'write').mockImplementation((data: any) => {
+    stdoutData += String(data);
+    return true;
+  });
+  jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  jest.clearAllMocks();
+  mockQdrant.scroll.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('handleList', () => {
+  const deps: ListDeps = {
+    loadCfg: jest.fn().mockResolvedValue(mockConfig),
+    createRepo: () => mockQdrant as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  };
+
+  it('resolves config context, builds filters, and calls scroll with normalized range', async () => {
+    await handleList(
+      {
+        entryType: 'decision,structure',
+        source: 'agent,manual',
+        from: '2026-01-01',
+        to: '2026-01-31',
+        limit: '5',
+      },
+      deps,
+    );
+
+    expect(mockQdrant.ensureCollection).toHaveBeenCalled();
+    expect(mockQdrant.scroll).toHaveBeenCalledWith(
+      {
+        must: [
+          { key: 'org', match: { value: 'llipe' } },
+          { key: 'entry_type', match: { any: ['decision', 'structure'] } },
+          { key: 'source', match: { any: ['agent', 'manual'] } },
+          {
+            key: 'timestamp_utc',
+            range: {
+              gte: '2026-01-01T00:00:00.000Z',
+              lte: '2026-01-31T23:59:59.999Z',
+            },
+          },
+        ],
+        should: [
+          { key: 'repo', match: { value: 'memo-cli' } },
+          { key: 'repo', match: { value: 'platform-docs' } },
+        ],
+      },
+      5,
+    );
+  });
+
+  it('defaults limit to 20 and renders the human empty state', async () => {
+    await handleList({}, deps);
+
+    expect(mockQdrant.scroll).toHaveBeenCalledWith(
+      {
+        must: [{ key: 'org', match: { value: 'llipe' } }],
+        should: [
+          { key: 'repo', match: { value: 'memo-cli' } },
+          { key: 'repo', match: { value: 'platform-docs' } },
+        ],
+      },
+      20,
+    );
+    expect(stdoutData).toContain('No entries found.');
+    expect(stdoutData).toContain('count: 0');
+  });
+
+  it('throws when repo context cannot be resolved', async () => {
+    const missingContextDeps: ListDeps = {
+      ...deps,
+      loadCfg: jest.fn().mockRejectedValue(new MemoError('CONFIG_NOT_FOUND', 'not found')),
+    };
+
+    await expect(handleList({}, missingContextDeps)).rejects.toMatchObject({
+      code: 'REPO_CONTEXT_UNRESOLVED',
+    });
+  });
+});

--- a/tests/unit/lib/list-filters.test.ts
+++ b/tests/unit/lib/list-filters.test.ts
@@ -1,0 +1,66 @@
+import { MemoError } from '../../../src/lib/errors.js';
+import { buildListFilters, normalizeListDateRange } from '../../../src/lib/list-filters.js';
+
+describe('normalizeListDateRange', () => {
+  it('normalizes bare dates to inclusive UTC day boundaries', () => {
+    expect(normalizeListDateRange({ from: '2026-01-01', to: '2026-01-31' })).toEqual({
+      from: '2026-01-01T00:00:00.000Z',
+      to: '2026-01-31T23:59:59.999Z',
+    });
+  });
+
+  it('throws when from is later than to', () => {
+    expect(() =>
+      normalizeListDateRange({
+        from: '2026-02-01T00:00:00.000Z',
+        to: '2026-01-31T23:59:59.999Z',
+      }),
+    ).toThrow(MemoError);
+  });
+});
+
+describe('buildListFilters', () => {
+  it('builds repo-scoped filters with date range, entry type, and source clauses', () => {
+    expect(
+      buildListFilters({
+        repo: 'memo-cli',
+        scope: 'repo',
+        org: 'llipe',
+        entryTypes: ['decision', 'structure'],
+        sources: ['agent'],
+        from: '2026-01-01',
+        to: '2026-01-31',
+      }),
+    ).toEqual({
+      must: [
+        { key: 'repo', match: { value: 'memo-cli' } },
+        { key: 'org', match: { value: 'llipe' } },
+        { key: 'entry_type', match: { any: ['decision', 'structure'] } },
+        { key: 'source', match: { value: 'agent' } },
+        {
+          key: 'timestamp_utc',
+          range: {
+            gte: '2026-01-01T00:00:00.000Z',
+            lte: '2026-01-31T23:59:59.999Z',
+          },
+        },
+      ],
+    });
+  });
+
+  it('builds related-scope filters using repo should clauses', () => {
+    expect(
+      buildListFilters({
+        repo: 'memo-cli',
+        scope: 'related',
+        relatedRepos: ['platform-docs', 'agent-sdk'],
+      }),
+    ).toEqual({
+      should: [
+        { key: 'repo', match: { value: 'memo-cli' } },
+        { key: 'repo', match: { value: 'platform-docs' } },
+        { key: 'repo', match: { value: 'agent-sdk' } },
+      ],
+    });
+  });
+});

--- a/tests/unit/lib/qdrant.test.ts
+++ b/tests/unit/lib/qdrant.test.ts
@@ -108,7 +108,7 @@ describe('QdrantRepository', () => {
   });
 
   describe('scroll()', () => {
-    it('calls client.scroll with filter and limit', async () => {
+    it('calls client.scroll with filter, limit, and descending timestamp order', async () => {
       mockScroll.mockResolvedValueOnce({
         points: [{ id: '1', payload: { text: 'hello' } }],
       });
@@ -119,7 +119,11 @@ describe('QdrantRepository', () => {
 
       expect(mockScroll).toHaveBeenCalledWith(
         'decisions',
-        expect.objectContaining({ filter, limit: 50 }),
+        expect.objectContaining({
+          filter,
+          limit: 50,
+          order_by: { key: 'timestamp_utc', direction: 'desc' },
+        }),
       );
       expect(results).toHaveLength(1);
     });

--- a/workstream/tasks-prd-001-mvp-plan.md
+++ b/workstream/tasks-prd-001-mvp-plan.md
@@ -16,6 +16,7 @@
 - `src/lib/config.ts` — Config loader, writer, validator
 - `src/lib/output.ts` — Human/JSON output formatter, interactive prompts
 - `src/lib/qdrant.ts` — `QdrantRepository` (bootstrap, upsert, search, scroll)
+- `src/lib/list-filters.ts` — List pre-filter builder for chronological listing
 - `src/lib/search-filters.ts` — Search pre-filter builder for repo/scope/tag semantics
 - `src/lib/embeddings.ts` — `EmbeddingsAdapter` interface + factory
 - `src/lib/retry.ts` — Retry with exponential backoff
@@ -163,22 +164,22 @@
   - [x] 5.16 Verify Acceptance Criterion: empty results return exit 0 with empty array
   - [x] 5.17 Run tests: `pnpm run test -- --testPathPattern="search"`
 
-- [ ] 6.0 Implement Story S-006 — Issue #6 - https://github.com/llipe/memo-cli/issues/6: `memo list` — Chronological Entry Listing
-  - [ ] 6.1 Implement `QdrantRepository.scroll()` with `order_by: { key: "timestamp_utc", direction: "desc" }` and filter support
-  - [ ] 6.2 Implement `buildListFilters()` in `src/lib/list-filters.ts` — repo, org, entry_type, source, scope, date range (`--from`/`--to` as Qdrant range filter)
-  - [ ] 6.3 Implement list command orchestration in `src/commands/list.ts`: parse flags → resolve context → build filters → scroll → format output
-  - [ ] 6.4 Implement human output for list results — table-style, `gray` meta labels, `cyan` repo, `bold` rationale snippet, timestamps
-  - [ ] 6.5 Implement human empty-results display with count 0 and message
-  - [ ] 6.6 Implement `--json` output: `filters` and `results` array with all payload fields
-  - [ ] 6.7 Implement auto-bootstrap on first list
-  - [ ] 6.8 Register `memo list` in `src/index.ts` with all flag definitions (`--from`, `--to`, `--repo`, `--org`, `--entry-type`, `--source`, `--scope`, `--limit`, `--json`)
-  - [ ] 6.9 Write unit tests: `tests/unit/lib/list-filters.test.ts` — date range filter, list filter composition
-  - [ ] 6.10 Write unit tests: `tests/unit/commands/list.test.ts` — command orchestration, filter composition
-  - [ ] 6.11 Write integration tests: `tests/integration/commands/list.test.ts` — `--json` contract, empty list, `--from`/`--to`, `--entry-type` filter
-  - [ ] 6.12 Verify Acceptance Criterion: entries ordered by `timestamp_utc` descending
-  - [ ] 6.13 Verify Acceptance Criterion: `--limit` defaults to 20
-  - [ ] 6.14 Verify Acceptance Criterion: empty results return exit 0 with count 0
-  - [ ] 6.15 Run tests: `pnpm run test -- --testPathPattern="list"`
+- [x] 6.0 Implement Story S-006 — Issue #6 - https://github.com/llipe/memo-cli/issues/6: `memo list` — Chronological Entry Listing
+  - [x] 6.1 Implement `QdrantRepository.scroll()` with `order_by: { key: "timestamp_utc", direction: "desc" }` and filter support
+  - [x] 6.2 Implement `buildListFilters()` in `src/lib/list-filters.ts` — repo, org, entry_type, source, scope, date range (`--from`/`--to` as Qdrant range filter)
+  - [x] 6.3 Implement list command orchestration in `src/commands/list.ts`: parse flags → resolve context → build filters → scroll → format output
+  - [x] 6.4 Implement human output for list results — table-style, `gray` meta labels, `cyan` repo, `bold` rationale snippet, timestamps
+  - [x] 6.5 Implement human empty-results display with count 0 and message
+  - [x] 6.6 Implement `--json` output: `filters` and `results` array with all payload fields
+  - [x] 6.7 Implement auto-bootstrap on first list
+  - [x] 6.8 Register `memo list` in `src/index.ts` with all flag definitions (`--from`, `--to`, `--repo`, `--org`, `--entry-type`, `--source`, `--scope`, `--limit`, `--json`)
+  - [x] 6.9 Write unit tests: `tests/unit/lib/list-filters.test.ts` — date range filter, list filter composition
+  - [x] 6.10 Write unit tests: `tests/unit/commands/list.test.ts` — command orchestration, filter composition
+  - [x] 6.11 Write integration tests: `tests/integration/commands/list.test.ts` — `--json` contract, empty list, `--from`/`--to`, `--entry-type` filter
+  - [x] 6.12 Verify Acceptance Criterion: entries ordered by `timestamp_utc` descending
+  - [x] 6.13 Verify Acceptance Criterion: `--limit` defaults to 20
+  - [x] 6.14 Verify Acceptance Criterion: empty results return exit 0 with count 0
+  - [x] 6.15 Run tests: `pnpm run test -- --testPathPattern="list"`
 
 - [ ] 7.0 Implement Story S-007 — Issue #7 - https://github.com/llipe/memo-cli/issues/7: Bootstrap Prompt Documentation & Validation Workflow
   - [ ] 7.1 Write `docs/bootstrap-guide.md` — prompt template, artifact selection guide (which files to pick: README, architecture docs, config files, key modules), 3 worked conversion examples (JSON → `memo write --source manual --json`)


### PR DESCRIPTION
## What
- implement Story S-006 (`memo list`) on top of the integration branch
- add ordered Qdrant scroll support and list-specific filter building
- add human and JSON list rendering plus unit and integration coverage

## Why
- add chronological listing with filters, JSON output, empty state handling, and auto-bootstrap support

## How
- extend `QdrantRepository.scroll()` to request descending `timestamp_utc` ordering
- add `buildListFilters()` with repo, related-scope, source, entry-type, and inclusive date range handling
- implement `memo list` orchestration and register the CLI command and flags
- add unit and integration coverage for filters, orchestration, JSON output, empty state, and ordering contract

## Testing
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test -- --testPathPattern="list"`
- `pnpm run test --no-coverage`

## Checklist
- [x] Story S-006 tasks completed
- [x] Tests updated and passing
- [x] Acceptance criteria verified

Closes #6