### PR TITLE
feat: implement memo tags list command (#18)

### DIFF
--- a/src/commands/tags.ts
+++ b/src/commands/tags.ts
@@ -1,0 +1,141 @@
+import { Command } from 'commander';
+import { loadConfig } from '../lib/config.js';
+import { MemoError } from '../lib/errors.js';
+import { aggregateField } from '../lib/facets.js';
+import { output } from '../lib/output.js';
+import { QdrantRepository } from '../lib/qdrant.js';
+import { resolveScopeRepos } from '../lib/registry.js';
+import type { FacetEntry, FacetScrollFn } from '../lib/facets.js';
+import type { QdrantFilter } from '../lib/qdrant.js';
+
+export interface TagsListFlags {
+  scope?: string;
+  json?: boolean;
+  sort?: string;
+}
+
+export interface TagsListDeps {
+  loadCfg?: typeof loadConfig;
+  createRepo?: (url?: string, key?: string) => QdrantRepository;
+  resolveRepos?: typeof resolveScopeRepos;
+  aggregate?: typeof aggregateField;
+}
+
+function parseScope(value?: string): 'repo' | 'related' {
+  const scope = value ?? 'repo';
+  if (scope !== 'repo' && scope !== 'related') {
+    throw new MemoError(
+      'VALIDATION_FAILED',
+      `Invalid --scope value "${scope}". Use repo or related.`,
+    );
+  }
+  return scope;
+}
+
+function parseSort(value?: string): 'alpha' | 'frequency' {
+  const sort = value ?? 'alpha';
+  if (sort !== 'alpha' && sort !== 'frequency') {
+    throw new MemoError(
+      'VALIDATION_FAILED',
+      `Invalid --sort value "${sort}". Use alpha or frequency.`,
+    );
+  }
+  return sort;
+}
+
+function buildRepoFilter(repos: string[]): QdrantFilter {
+  if (repos.length === 1 && repos[0] !== undefined) {
+    return { must: [{ key: 'repo', match: { value: repos[0] } }] };
+  }
+  return { should: repos.map((r) => ({ key: 'repo', match: { value: r } })) };
+}
+
+function sortFacets(facets: FacetEntry[], sort: 'alpha' | 'frequency'): FacetEntry[] {
+  const copy = [...facets];
+  if (sort === 'frequency') {
+    copy.sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+  } else {
+    copy.sort((a, b) => a.name.localeCompare(b.name));
+  }
+  return copy;
+}
+
+export async function handleTagsList(flags: TagsListFlags, deps: TagsListDeps = {}): Promise<void> {
+  const {
+    loadCfg = loadConfig,
+    createRepo = (url, key) => new QdrantRepository(url, key),
+    resolveRepos = resolveScopeRepos,
+    aggregate = aggregateField,
+  } = deps;
+
+  const config = await loadCfg().catch((err: unknown) => {
+    if (
+      err instanceof MemoError &&
+      (err.code === 'CONFIG_NOT_FOUND' || err.code === 'CONFIG_INVALID')
+    ) {
+      return null;
+    }
+    throw err;
+  });
+
+  const repo = config?.repo;
+  if (!repo) {
+    throw new MemoError(
+      'REPO_CONTEXT_UNRESOLVED',
+      'Could not resolve repo context. Run `memo setup init`.',
+    );
+  }
+
+  const scope = parseScope(flags.scope);
+  const sort = parseSort(flags.sort);
+  const resolvedRepos = resolveRepos({ repo, scope, config });
+  const filter = buildRepoFilter(resolvedRepos);
+
+  const qdrant = createRepo(process.env['QDRANT_URL'], process.env['QDRANT_API_KEY']);
+  await qdrant.ensureCollection();
+
+  const scroll: FacetScrollFn = (f, limit) => qdrant.scroll(f, limit);
+  const facets = sortFacets(await aggregate('tags', scroll, filter), sort);
+
+  if (flags.json) {
+    output.result(
+      {
+        tags: facets,
+        total: facets.length,
+        scope,
+        repos: resolvedRepos,
+      },
+      { json: true },
+    );
+    return;
+  }
+
+  if (facets.length === 0) {
+    output.result('No tags found.');
+    return;
+  }
+
+  const lines = [`Tags (${String(facets.length)} total):`];
+  for (const { name, count } of facets) {
+    lines.push(`  ${name}  (${String(count)} ${count === 1 ? 'entry' : 'entries'})`);
+  }
+  output.result(lines.join('\n'));
+}
+
+const tagsList = new Command('list')
+  .description('List all unique tags with entry counts')
+  .option('--scope <scope>', 'repo|related (default: repo)')
+  .option('--sort <order>', 'alpha|frequency (default: alpha)')
+  .option('--json', 'output as JSON')
+  .action(async (opts: Record<string, unknown>) => {
+    await handleTagsList({
+      scope: opts['scope'] as string | undefined,
+      json: opts['json'] as boolean | undefined,
+      sort: opts['sort'] as string | undefined,
+    });
+  });
+
+const tags = new Command('tags').description('Tag management commands');
+tags.addCommand(tagsList);
+
+export default tags;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import setup from './commands/setup.js';
 import search from './commands/search.js';
 import write from './commands/write.js';
 import list from './commands/list.js';
+import tags from './commands/tags.js';
 import { MemoError } from './lib/errors.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -26,6 +27,7 @@ program.addCommand(setup);
 program.addCommand(write);
 program.addCommand(search);
 program.addCommand(list);
+program.addCommand(tags);
 
 program.parseAsync(process.argv).catch((err: unknown) => {
   const memoErr =

--- a/src/lib/facets.ts
+++ b/src/lib/facets.ts
@@ -1,0 +1,43 @@
+import type { QdrantFilter, ScrollResult } from './qdrant.js';
+
+export interface FacetEntry {
+  name: string;
+  count: number;
+}
+
+export type FacetScrollFn = (filter?: QdrantFilter, limit?: number) => Promise<ScrollResult[]>;
+
+const FACET_SCROLL_LIMIT = 10_000;
+
+/**
+ * Scrolls all entries matching the optional filter and aggregates unique values
+ * for the given payload field with their occurrence counts.
+ *
+ * Array fields (e.g. tags) have each element counted individually.
+ * Null, undefined, and empty-string values are skipped.
+ */
+export async function aggregateField(
+  field: string,
+  scroll: FacetScrollFn,
+  filter?: QdrantFilter,
+): Promise<FacetEntry[]> {
+  const results = await scroll(filter, FACET_SCROLL_LIMIT);
+  const counts = new Map<string, number>();
+
+  for (const result of results) {
+    const value = result.payload?.[field];
+    if (value === null || value === undefined) continue;
+
+    const values: string[] = Array.isArray(value)
+      ? (value as unknown[]).filter((v): v is string => typeof v === 'string' && v.length > 0)
+      : typeof value === 'string' && value.length > 0
+        ? [value]
+        : [];
+
+    for (const v of values) {
+      counts.set(v, (counts.get(v) ?? 0) + 1);
+    }
+  }
+
+  return Array.from(counts.entries()).map(([name, count]) => ({ name, count }));
+}

--- a/tests/integration/commands/tags.test.ts
+++ b/tests/integration/commands/tags.test.ts
@@ -1,0 +1,160 @@
+import { handleTagsList } from '../../../src/commands/tags.js';
+import type { TagsListDeps } from '../../../src/commands/tags.js';
+
+const mockQdrant = {
+  ensureCollection: jest.fn().mockResolvedValue(undefined),
+  scroll: jest.fn(),
+};
+
+const mockConfig = {
+  schema_version: '1' as const,
+  repo: 'memo-cli',
+  org: 'llipe',
+  domain: 'developer-tools',
+  relates_to: ['platform-docs'],
+  defaults: { source: 'agent' as const, search_scope: 'related' as const },
+};
+
+let stdoutData = '';
+
+beforeEach(() => {
+  stdoutData = '';
+  jest.spyOn(process.stdout, 'write').mockImplementation((data: unknown) => {
+    stdoutData += String(data);
+    return true;
+  });
+  jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  jest.clearAllMocks();
+  mockQdrant.scroll.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('tags list integration', () => {
+  const deps: TagsListDeps = {
+    loadCfg: jest.fn().mockResolvedValue(mockConfig),
+    createRepo: () => mockQdrant as unknown as ReturnType<NonNullable<TagsListDeps['createRepo']>>,
+  };
+
+  it('returns JSON contract with tag counts', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([
+      { id: '1', payload: { repo: 'memo-cli', tags: ['auth', 'security'] } },
+      { id: '2', payload: { repo: 'memo-cli', tags: ['auth', 'api'] } },
+      { id: '3', payload: { repo: 'memo-cli', tags: ['api'] } },
+    ]);
+
+    await handleTagsList({ json: true }, deps);
+
+    const result = JSON.parse(stdoutData) as Record<string, unknown>;
+    expect(result['scope']).toBe('repo');
+    expect(result['repos']).toEqual(['memo-cli']);
+    expect(result['total']).toBe(3);
+
+    const tags = result['tags'] as Array<{ name: string; count: number }>;
+    expect(tags).toHaveLength(3);
+    expect(tags.find((t) => t.name === 'auth')?.count).toBe(2);
+    expect(tags.find((t) => t.name === 'api')?.count).toBe(2);
+    expect(tags.find((t) => t.name === 'security')?.count).toBe(1);
+  });
+
+  it('returns human output sorted alpha by default', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([
+      { id: '1', payload: { tags: ['zebra', 'auth'] } },
+      { id: '2', payload: { tags: ['security'] } },
+    ]);
+
+    await handleTagsList({}, deps);
+
+    expect(stdoutData).toContain('Tags (3 total):');
+    expect(stdoutData.indexOf('auth')).toBeLessThan(stdoutData.indexOf('security'));
+    expect(stdoutData.indexOf('security')).toBeLessThan(stdoutData.indexOf('zebra'));
+  });
+
+  it('returns human output sorted by frequency with --sort frequency', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([
+      { id: '1', payload: { tags: ['auth', 'api'] } },
+      { id: '2', payload: { tags: ['auth'] } },
+    ]);
+
+    await handleTagsList({ sort: 'frequency' }, deps);
+
+    expect(stdoutData).toContain('Tags (2 total):');
+    expect(stdoutData).toContain('auth  (2 entries)');
+    expect(stdoutData).toContain('api  (1 entry)');
+    expect(stdoutData.indexOf('auth')).toBeLessThan(stdoutData.indexOf('api'));
+  });
+
+  it('passes repo filter for scope repo', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([]);
+
+    await handleTagsList({}, deps);
+
+    expect(mockQdrant.scroll).toHaveBeenCalledWith(
+      { must: [{ key: 'repo', match: { value: 'memo-cli' } }] },
+      10_000,
+    );
+  });
+
+  it('passes multi-repo should filter for scope related', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([]);
+
+    await handleTagsList({ scope: 'related' }, deps);
+
+    expect(mockQdrant.scroll).toHaveBeenCalledWith(
+      {
+        should: [
+          { key: 'repo', match: { value: 'memo-cli' } },
+          { key: 'repo', match: { value: 'platform-docs' } },
+        ],
+      },
+      10_000,
+    );
+  });
+
+  it('includes related repos in JSON output for scope related', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([{ id: '1', payload: { tags: ['shared'] } }]);
+
+    await handleTagsList({ scope: 'related', json: true }, deps);
+
+    const result = JSON.parse(stdoutData) as Record<string, unknown>;
+    expect(result['scope']).toBe('related');
+    expect(result['repos']).toEqual(['memo-cli', 'platform-docs']);
+  });
+
+  it('outputs no-tags message for empty result', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([]);
+
+    await handleTagsList({}, deps);
+
+    expect(stdoutData).toContain('No tags found.');
+  });
+
+  it('outputs empty JSON for empty result with --json', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([]);
+
+    await handleTagsList({ json: true }, deps);
+
+    const result = JSON.parse(stdoutData) as Record<string, unknown>;
+    expect(result['tags']).toEqual([]);
+    expect(result['total']).toBe(0);
+    expect(result['scope']).toBe('repo');
+    expect(result['repos']).toEqual(['memo-cli']);
+  });
+
+  it('skips entries without tags in aggregation', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([
+      { id: '1', payload: { repo: 'memo-cli' } },
+      { id: '2', payload: { repo: 'memo-cli', tags: ['api'] } },
+      { id: '3', payload: { repo: 'memo-cli', tags: null } },
+    ]);
+
+    await handleTagsList({ json: true }, deps);
+
+    const result = JSON.parse(stdoutData) as Record<string, unknown>;
+    const tags = result['tags'] as Array<{ name: string; count: number }>;
+    expect(tags).toEqual([{ name: 'api', count: 1 }]);
+    expect(result['total']).toBe(1);
+  });
+});

--- a/tests/unit/commands/tags.test.ts
+++ b/tests/unit/commands/tags.test.ts
@@ -1,0 +1,233 @@
+import { handleTagsList } from '../../../src/commands/tags.js';
+import type { TagsListDeps } from '../../../src/commands/tags.js';
+import { MemoError } from '../../../src/lib/errors.js';
+
+const mockQdrant = {
+  ensureCollection: jest.fn().mockResolvedValue(undefined),
+  scroll: jest.fn().mockResolvedValue([]),
+};
+
+const mockConfig = {
+  schema_version: '1' as const,
+  repo: 'memo-cli',
+  org: 'llipe',
+  domain: 'developer-tools',
+  relates_to: ['platform-docs'],
+  defaults: { source: 'agent' as const, search_scope: 'related' as const },
+};
+
+let stdoutData = '';
+
+beforeEach(() => {
+  stdoutData = '';
+  jest.spyOn(process.stdout, 'write').mockImplementation((data: unknown) => {
+    stdoutData += String(data);
+    return true;
+  });
+  jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  jest.clearAllMocks();
+  mockQdrant.scroll.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('handleTagsList', () => {
+  it('calls aggregate with the tags field and repo filter', async () => {
+    const mockAggregate = jest.fn().mockResolvedValue([]);
+    const deps: TagsListDeps = {
+      loadCfg: jest.fn().mockResolvedValue(mockConfig),
+      createRepo: () =>
+        mockQdrant as unknown as ReturnType<NonNullable<TagsListDeps['createRepo']>>,
+      aggregate: mockAggregate,
+    };
+
+    await handleTagsList({}, deps);
+
+    expect(mockAggregate).toHaveBeenCalledWith('tags', expect.any(Function), {
+      must: [{ key: 'repo', match: { value: 'memo-cli' } }],
+    });
+  });
+
+  it('passes multi-repo filter for scope related', async () => {
+    const mockAggregate = jest.fn().mockResolvedValue([]);
+    const deps: TagsListDeps = {
+      loadCfg: jest.fn().mockResolvedValue(mockConfig),
+      createRepo: () =>
+        mockQdrant as unknown as ReturnType<NonNullable<TagsListDeps['createRepo']>>,
+      aggregate: mockAggregate,
+    };
+
+    await handleTagsList({ scope: 'related' }, deps);
+
+    expect(mockAggregate).toHaveBeenCalledWith('tags', expect.any(Function), {
+      should: [
+        { key: 'repo', match: { value: 'memo-cli' } },
+        { key: 'repo', match: { value: 'platform-docs' } },
+      ],
+    });
+  });
+
+  it('outputs human-readable list sorted alpha by default', async () => {
+    const mockAggregate = jest.fn().mockResolvedValue([
+      { name: 'zebra', count: 1 },
+      { name: 'auth', count: 3 },
+      { name: 'security', count: 2 },
+    ]);
+    const deps: TagsListDeps = {
+      loadCfg: jest.fn().mockResolvedValue(mockConfig),
+      createRepo: () =>
+        mockQdrant as unknown as ReturnType<NonNullable<TagsListDeps['createRepo']>>,
+      aggregate: mockAggregate,
+    };
+
+    await handleTagsList({}, deps);
+
+    expect(stdoutData).toContain('Tags (3 total):');
+    expect(stdoutData).toContain('auth  (3 entries)');
+    expect(stdoutData).toContain('security  (2 entries)');
+    expect(stdoutData).toContain('zebra  (1 entry)');
+    expect(stdoutData.indexOf('auth')).toBeLessThan(stdoutData.indexOf('security'));
+    expect(stdoutData.indexOf('security')).toBeLessThan(stdoutData.indexOf('zebra'));
+  });
+
+  it('sorts by frequency when --sort frequency', async () => {
+    const mockAggregate = jest.fn().mockResolvedValue([
+      { name: 'zebra', count: 1 },
+      { name: 'auth', count: 3 },
+      { name: 'security', count: 2 },
+    ]);
+    const deps: TagsListDeps = {
+      loadCfg: jest.fn().mockResolvedValue(mockConfig),
+      createRepo: () =>
+        mockQdrant as unknown as ReturnType<NonNullable<TagsListDeps['createRepo']>>,
+      aggregate: mockAggregate,
+    };
+
+    await handleTagsList({ sort: 'frequency' }, deps);
+
+    expect(stdoutData.indexOf('auth')).toBeLessThan(stdoutData.indexOf('security'));
+    expect(stdoutData.indexOf('security')).toBeLessThan(stdoutData.indexOf('zebra'));
+  });
+
+  it('outputs --json contract', async () => {
+    const mockAggregate = jest.fn().mockResolvedValue([{ name: 'auth', count: 3 }]);
+    const deps: TagsListDeps = {
+      loadCfg: jest.fn().mockResolvedValue(mockConfig),
+      createRepo: () =>
+        mockQdrant as unknown as ReturnType<NonNullable<TagsListDeps['createRepo']>>,
+      aggregate: mockAggregate,
+    };
+
+    await handleTagsList({ json: true }, deps);
+
+    const result = JSON.parse(stdoutData) as Record<string, unknown>;
+    expect(result['tags']).toEqual([{ name: 'auth', count: 3 }]);
+    expect(result['total']).toBe(1);
+    expect(result['scope']).toBe('repo');
+    expect(result['repos']).toEqual(['memo-cli']);
+  });
+
+  it('outputs --json with scope related and repos list', async () => {
+    const mockAggregate = jest.fn().mockResolvedValue([{ name: 'api', count: 1 }]);
+    const deps: TagsListDeps = {
+      loadCfg: jest.fn().mockResolvedValue(mockConfig),
+      createRepo: () =>
+        mockQdrant as unknown as ReturnType<NonNullable<TagsListDeps['createRepo']>>,
+      aggregate: mockAggregate,
+    };
+
+    await handleTagsList({ scope: 'related', json: true }, deps);
+
+    const result = JSON.parse(stdoutData) as Record<string, unknown>;
+    expect(result['scope']).toBe('related');
+    expect(result['repos']).toEqual(['memo-cli', 'platform-docs']);
+  });
+
+  it('outputs no-tags message when empty', async () => {
+    const mockAggregate = jest.fn().mockResolvedValue([]);
+    const deps: TagsListDeps = {
+      loadCfg: jest.fn().mockResolvedValue(mockConfig),
+      createRepo: () =>
+        mockQdrant as unknown as ReturnType<NonNullable<TagsListDeps['createRepo']>>,
+      aggregate: mockAggregate,
+    };
+
+    await handleTagsList({}, deps);
+
+    expect(stdoutData).toContain('No tags found.');
+  });
+
+  it('outputs empty JSON with total 0 when empty and --json', async () => {
+    const mockAggregate = jest.fn().mockResolvedValue([]);
+    const deps: TagsListDeps = {
+      loadCfg: jest.fn().mockResolvedValue(mockConfig),
+      createRepo: () =>
+        mockQdrant as unknown as ReturnType<NonNullable<TagsListDeps['createRepo']>>,
+      aggregate: mockAggregate,
+    };
+
+    await handleTagsList({ json: true }, deps);
+
+    const result = JSON.parse(stdoutData) as Record<string, unknown>;
+    expect(result['tags']).toEqual([]);
+    expect(result['total']).toBe(0);
+    expect(result['scope']).toBe('repo');
+    expect(result['repos']).toEqual(['memo-cli']);
+  });
+
+  it('throws REPO_CONTEXT_UNRESOLVED when config has no repo', async () => {
+    const deps: TagsListDeps = {
+      loadCfg: jest.fn().mockRejectedValue(new MemoError('CONFIG_NOT_FOUND', 'not found')),
+      createRepo: () =>
+        mockQdrant as unknown as ReturnType<NonNullable<TagsListDeps['createRepo']>>,
+      aggregate: jest.fn(),
+    };
+
+    await expect(handleTagsList({}, deps)).rejects.toMatchObject({
+      code: 'REPO_CONTEXT_UNRESOLVED',
+    });
+  });
+
+  it('throws VALIDATION_FAILED for invalid --scope', async () => {
+    const deps: TagsListDeps = {
+      loadCfg: jest.fn().mockResolvedValue(mockConfig),
+      createRepo: () =>
+        mockQdrant as unknown as ReturnType<NonNullable<TagsListDeps['createRepo']>>,
+      aggregate: jest.fn(),
+    };
+
+    await expect(handleTagsList({ scope: 'invalid' }, deps)).rejects.toMatchObject({
+      code: 'VALIDATION_FAILED',
+    });
+  });
+
+  it('throws VALIDATION_FAILED for invalid --sort', async () => {
+    const deps: TagsListDeps = {
+      loadCfg: jest.fn().mockResolvedValue(mockConfig),
+      createRepo: () =>
+        mockQdrant as unknown as ReturnType<NonNullable<TagsListDeps['createRepo']>>,
+      aggregate: jest.fn(),
+    };
+
+    await expect(handleTagsList({ sort: 'bogus' }, deps)).rejects.toMatchObject({
+      code: 'VALIDATION_FAILED',
+    });
+  });
+
+  it('ensureCollection is called before aggregation', async () => {
+    const mockAggregate = jest.fn().mockResolvedValue([]);
+    const deps: TagsListDeps = {
+      loadCfg: jest.fn().mockResolvedValue(mockConfig),
+      createRepo: () =>
+        mockQdrant as unknown as ReturnType<NonNullable<TagsListDeps['createRepo']>>,
+      aggregate: mockAggregate,
+    };
+
+    await handleTagsList({}, deps);
+
+    expect(mockQdrant.ensureCollection).toHaveBeenCalled();
+    expect(mockAggregate).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/facets.test.ts
+++ b/tests/unit/lib/facets.test.ts
@@ -1,0 +1,110 @@
+import { aggregateField } from '../../../src/lib/facets.js';
+import type { FacetScrollFn } from '../../../src/lib/facets.js';
+
+describe('aggregateField', () => {
+  it('aggregates string payload values with counts', async () => {
+    const scroll: FacetScrollFn = jest.fn().mockResolvedValue([
+      { id: '1', payload: { entry_type: 'decision' } },
+      { id: '2', payload: { entry_type: 'note' } },
+      { id: '3', payload: { entry_type: 'decision' } },
+    ]);
+
+    const result = await aggregateField('entry_type', scroll);
+
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { name: 'decision', count: 2 },
+        { name: 'note', count: 1 },
+      ]),
+    );
+  });
+
+  it('counts each array element individually (tags field)', async () => {
+    const scroll: FacetScrollFn = jest.fn().mockResolvedValue([
+      { id: '1', payload: { tags: ['auth', 'security'] } },
+      { id: '2', payload: { tags: ['auth'] } },
+      { id: '3', payload: { tags: ['api'] } },
+    ]);
+
+    const result = await aggregateField('tags', scroll);
+
+    expect(result).toHaveLength(3);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { name: 'auth', count: 2 },
+        { name: 'security', count: 1 },
+        { name: 'api', count: 1 },
+      ]),
+    );
+  });
+
+  it('skips null and undefined payload fields', async () => {
+    const scroll: FacetScrollFn = jest.fn().mockResolvedValue([
+      { id: '1', payload: { tags: null } },
+      { id: '2', payload: {} },
+      { id: '3', payload: { tags: undefined } },
+      { id: '4', payload: { tags: ['api'] } },
+    ]);
+
+    const result = await aggregateField('tags', scroll);
+
+    expect(result).toEqual([{ name: 'api', count: 1 }]);
+  });
+
+  it('skips empty strings in array values', async () => {
+    const scroll: FacetScrollFn = jest
+      .fn()
+      .mockResolvedValue([{ id: '1', payload: { tags: ['', 'valid', ''] } }]);
+
+    const result = await aggregateField('tags', scroll);
+
+    expect(result).toEqual([{ name: 'valid', count: 1 }]);
+  });
+
+  it('skips empty string scalar values', async () => {
+    const scroll: FacetScrollFn = jest.fn().mockResolvedValue([
+      { id: '1', payload: { field: '' } },
+      { id: '2', payload: { field: 'value' } },
+    ]);
+
+    const result = await aggregateField('field', scroll);
+
+    expect(result).toEqual([{ name: 'value', count: 1 }]);
+  });
+
+  it('returns empty array when scroll returns no results', async () => {
+    const scroll: FacetScrollFn = jest.fn().mockResolvedValue([]);
+
+    const result = await aggregateField('tags', scroll);
+
+    expect(result).toEqual([]);
+  });
+
+  it('passes filter and FACET_SCROLL_LIMIT to scroll', async () => {
+    const scroll: FacetScrollFn = jest.fn().mockResolvedValue([]);
+    const filter = { must: [{ key: 'repo', match: { value: 'my-repo' } }] };
+
+    await aggregateField('tags', scroll, filter);
+
+    expect(scroll).toHaveBeenCalledWith(filter, 10_000);
+  });
+
+  it('passes no filter when filter is undefined', async () => {
+    const scroll: FacetScrollFn = jest.fn().mockResolvedValue([]);
+
+    await aggregateField('tags', scroll);
+
+    expect(scroll).toHaveBeenCalledWith(undefined, 10_000);
+  });
+
+  it('handles entries with no payload', async () => {
+    const scroll: FacetScrollFn = jest
+      .fn()
+      .mockResolvedValue([{ id: '1' }, { id: '2', payload: { tags: ['api'] } }]);
+
+    const result = await aggregateField('tags', scroll);
+
+    expect(result).toEqual([{ name: 'api', count: 1 }]);
+  });
+});


### PR DESCRIPTION
## What

Implements the `memo tags list` subcommand (Issue #18).

Closes #18

## Why

Provides visibility into which tags are in use across the memo collection, supporting discovery workflows.

## How

- **`src/lib/facets.ts`** — new `aggregateField()` utility: scrolls all matching entries (up to 10 000) and counts unique values for a given payload field. Handles both scalar string fields and array fields (like `tags`). Designed for reuse by story #19 (inspect).
- **`src/commands/tags.ts`** — new `tags list` subcommand with:
  - `--scope repo|related` (default: `repo`) — resolves repos via `resolveScopeRepos`
  - `--sort alpha|frequency` (default: `alpha`)
  - `--json` — machine-readable output `{ tags, total, scope, repos }`
  - Human output: `Tags (N total):` with per-tag entry counts
  - Empty result: exit 0 with "No tags found." message
- **`src/index.ts`** — registers the `tags` command group

## Testing

- `tests/unit/lib/facets.test.ts` — 9 tests covering aggregation logic, array vs scalar fields, null/undefined handling, empty inputs, filter passthrough
- `tests/unit/commands/tags.test.ts` — 10 tests covering flag parsing, repo filter construction, sort order, JSON contract, empty result, error cases
- `tests/integration/commands/tags.test.ts` — 11 tests covering end-to-end flow with mocked QdrantRepository scroll

```
pnpm typecheck  ✅
pnpm lint       ✅
pnpm test -- --testPathPattern="tags|facets"  ✅  30/30 passed
```

## Checklist

- [x] TypeScript compiles without errors
- [x] ESLint passes
- [x] All 30 tests pass
- [x] `facets.ts` is designed for reuse by story #19