### PR TITLE
feat: implement memo inspect command (#19)

### DIFF
--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -1,0 +1,132 @@
+import { Command } from 'commander';
+import { aggregateMultipleFields } from '../lib/facets.js';
+import { output } from '../lib/output.js';
+import { QdrantRepository } from '../lib/qdrant.js';
+import type { FacetScrollFn, MultiFacetResult, RepoFacetEntry } from '../lib/facets.js';
+
+export interface InspectFlags {
+  orgs?: boolean;
+  repos?: boolean;
+  domains?: boolean;
+  json?: boolean;
+}
+
+export interface InspectDeps {
+  createRepo?: (url?: string, key?: string) => QdrantRepository;
+  aggregate?: typeof aggregateMultipleFields;
+}
+
+function hasEntries(facets: MultiFacetResult): boolean {
+  return facets.orgs.length > 0 || facets.repos.length > 0 || facets.domains.length > 0;
+}
+
+function sortByAlpha<T extends { name: string }>(items: T[]): T[] {
+  return [...items].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function handleInspect(flags: InspectFlags, deps: InspectDeps = {}): Promise<void> {
+  const {
+    createRepo = (url, key) => new QdrantRepository(url, key),
+    aggregate = aggregateMultipleFields,
+  } = deps;
+
+  const qdrant = createRepo(process.env['QDRANT_URL'], process.env['QDRANT_API_KEY']);
+  await qdrant.ensureCollection();
+
+  const scroll: FacetScrollFn = (f, limit) => qdrant.scroll(f, limit);
+  const facets = await aggregate(scroll);
+
+  const showOrgs = !flags.repos && !flags.domains;
+  const showRepos = !flags.orgs && !flags.domains;
+  const showDomains = !flags.orgs && !flags.repos;
+
+  // When facet flags narrow down to something, respect that selection
+  const filterOrgs = flags.orgs === true;
+  const filterRepos = flags.repos === true;
+  const filterDomains = flags.domains === true;
+
+  const anyFacetFlag = filterOrgs || filterRepos || filterDomains;
+
+  const displayOrgs = anyFacetFlag ? filterOrgs : showOrgs;
+  const displayRepos = anyFacetFlag ? filterRepos : showRepos;
+  const displayDomains = anyFacetFlag ? filterDomains : showDomains;
+
+  const orgs = displayOrgs ? sortByAlpha(facets.orgs) : [];
+  const repos = displayRepos ? sortByAlpha(facets.repos) : [];
+  const domains = displayDomains ? sortByAlpha(facets.domains) : [];
+
+  const totalEntries = orgs.length + repos.length + domains.length;
+
+  if (!hasEntries(facets)) {
+    output.result('No entries found.');
+    return;
+  }
+
+  if (flags.json) {
+    const jsonResult: Record<string, unknown> = {};
+    if (displayOrgs) jsonResult['orgs'] = orgs.map(({ name, count }) => ({ name, count }));
+    if (displayRepos) {
+      jsonResult['repos'] = repos.map((r: RepoFacetEntry) => {
+        const entry: Record<string, unknown> = { name: r.name, count: r.count };
+        if (r.org) entry['org'] = r.org;
+        if (r.domain) entry['domain'] = r.domain;
+        return entry;
+      });
+    }
+    if (displayDomains) jsonResult['domains'] = domains.map(({ name, count }) => ({ name, count }));
+    output.result(jsonResult, { json: true });
+    return;
+  }
+
+  if (totalEntries === 0) {
+    output.result('No entries found.');
+    return;
+  }
+
+  const lines: string[] = [];
+
+  if (displayOrgs && orgs.length > 0) {
+    lines.push(`Organizations (${String(orgs.length)}):`);
+    for (const { name, count } of orgs) {
+      lines.push(`  ${name}  (${String(count)} ${count === 1 ? 'entry' : 'entries'})`);
+    }
+  }
+
+  if (displayRepos && repos.length > 0) {
+    if (lines.length > 0) lines.push('');
+    lines.push(`Repositories (${String(repos.length)}):`);
+    for (const r of repos) {
+      const annotation = r.domain ? `  [${r.domain}]` : '';
+      lines.push(
+        `  ${r.name}${annotation}  (${String(r.count)} ${r.count === 1 ? 'entry' : 'entries'})`,
+      );
+    }
+  }
+
+  if (displayDomains && domains.length > 0) {
+    if (lines.length > 0) lines.push('');
+    lines.push(`Domains (${String(domains.length)}):`);
+    for (const { name, count } of domains) {
+      lines.push(`  ${name}  (${String(count)} ${count === 1 ? 'entry' : 'entries'})`);
+    }
+  }
+
+  output.result(lines.join('\n'));
+}
+
+const inspect = new Command('inspect')
+  .description('Inspect all entries by org, repo, and domain facets')
+  .option('--orgs', 'show only organizations facet')
+  .option('--repos', 'show only repositories facet')
+  .option('--domains', 'show only domains facet')
+  .option('--json', 'output as JSON')
+  .action(async (opts: Record<string, unknown>) => {
+    await handleInspect({
+      orgs: opts['orgs'] as boolean | undefined,
+      repos: opts['repos'] as boolean | undefined,
+      domains: opts['domains'] as boolean | undefined,
+      json: opts['json'] as boolean | undefined,
+    });
+  });
+
+export default inspect;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import search from './commands/search.js';
 import write from './commands/write.js';
 import list from './commands/list.js';
 import tags from './commands/tags.js';
+import inspect from './commands/inspect.js';
 import { MemoError } from './lib/errors.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -28,6 +29,7 @@ program.addCommand(write);
 program.addCommand(search);
 program.addCommand(list);
 program.addCommand(tags);
+program.addCommand(inspect);
 
 program.parseAsync(process.argv).catch((err: unknown) => {
   const memoErr =

--- a/src/lib/facets.ts
+++ b/src/lib/facets.ts
@@ -5,6 +5,19 @@ export interface FacetEntry {
   count: number;
 }
 
+export interface RepoFacetEntry {
+  name: string;
+  org?: string;
+  domain?: string;
+  count: number;
+}
+
+export interface MultiFacetResult {
+  orgs: FacetEntry[];
+  repos: RepoFacetEntry[];
+  domains: FacetEntry[];
+}
+
 export type FacetScrollFn = (filter?: QdrantFilter, limit?: number) => Promise<ScrollResult[]>;
 
 const FACET_SCROLL_LIMIT = 10_000;
@@ -40,4 +53,65 @@ export async function aggregateField(
   }
 
   return Array.from(counts.entries()).map(([name, count]) => ({ name, count }));
+}
+
+/**
+ * Scrolls all entries in a single pass and simultaneously aggregates counts for
+ * the `org`, `repo`, and `domain` payload fields.
+ *
+ * For repos, the first observed `org` and `domain` values are captured to enrich
+ * the output without requiring additional scroll passes.
+ */
+export async function aggregateMultipleFields(scroll: FacetScrollFn): Promise<MultiFacetResult> {
+  const results = await scroll(undefined, FACET_SCROLL_LIMIT);
+
+  const orgCounts = new Map<string, number>();
+  const repoCounts = new Map<string, number>();
+  const repoMeta = new Map<string, { org?: string; domain?: string }>();
+  const domainCounts = new Map<string, number>();
+
+  for (const result of results) {
+    const p = result.payload;
+    if (!p) continue;
+
+    const orgVal = typeof p['org'] === 'string' && p['org'].length > 0 ? p['org'] : undefined;
+    const repoVal = typeof p['repo'] === 'string' && p['repo'].length > 0 ? p['repo'] : undefined;
+    const domainVal =
+      typeof p['domain'] === 'string' && p['domain'].length > 0 ? p['domain'] : undefined;
+
+    if (orgVal) {
+      orgCounts.set(orgVal, (orgCounts.get(orgVal) ?? 0) + 1);
+    }
+
+    if (repoVal) {
+      repoCounts.set(repoVal, (repoCounts.get(repoVal) ?? 0) + 1);
+      if (!repoMeta.has(repoVal)) {
+        repoMeta.set(repoVal, { org: orgVal, domain: domainVal });
+      }
+    }
+
+    if (domainVal) {
+      domainCounts.set(domainVal, (domainCounts.get(domainVal) ?? 0) + 1);
+    }
+  }
+
+  const orgs: FacetEntry[] = Array.from(orgCounts.entries()).map(([name, count]) => ({
+    name,
+    count,
+  }));
+
+  const repos: RepoFacetEntry[] = Array.from(repoCounts.entries()).map(([name, count]) => {
+    const meta = repoMeta.get(name);
+    const entry: RepoFacetEntry = { name, count };
+    if (meta?.org) entry.org = meta.org;
+    if (meta?.domain) entry.domain = meta.domain;
+    return entry;
+  });
+
+  const domains: FacetEntry[] = Array.from(domainCounts.entries()).map(([name, count]) => ({
+    name,
+    count,
+  }));
+
+  return { orgs, repos, domains };
 }

--- a/tests/integration/commands/inspect.test.ts
+++ b/tests/integration/commands/inspect.test.ts
@@ -1,0 +1,159 @@
+import { handleInspect } from '../../../src/commands/inspect.js';
+import type { InspectDeps } from '../../../src/commands/inspect.js';
+
+const mockQdrant = {
+  ensureCollection: jest.fn().mockResolvedValue(undefined),
+  scroll: jest.fn(),
+};
+
+let stdoutData = '';
+
+beforeEach(() => {
+  stdoutData = '';
+  jest.spyOn(process.stdout, 'write').mockImplementation((data: unknown) => {
+    stdoutData += String(data);
+    return true;
+  });
+  jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  jest.clearAllMocks();
+  mockQdrant.scroll.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const deps: InspectDeps = {
+  createRepo: () => mockQdrant as unknown as ReturnType<NonNullable<InspectDeps['createRepo']>>,
+};
+
+describe('inspect integration', () => {
+  it('aggregates org, repo, and domain in a single scroll pass', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([
+      { id: '1', payload: { org: 'llipe', repo: 'memo-cli', domain: 'developer-tools' } },
+      { id: '2', payload: { org: 'llipe', repo: 'memo-cli', domain: 'developer-tools' } },
+      { id: '3', payload: { org: 'llipe', repo: 'platform-docs', domain: 'developer-tools' } },
+      { id: '4', payload: { org: 'acme', repo: 'acme-api', domain: 'infra' } },
+    ]);
+
+    await handleInspect({}, deps);
+
+    expect(mockQdrant.scroll).toHaveBeenCalledTimes(1);
+    expect(stdoutData).toContain('Organizations (2):');
+    expect(stdoutData).toContain('Repositories (3):');
+    expect(stdoutData).toContain('Domains (2):');
+  });
+
+  it('returns JSON contract with counts from real scroll data', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([
+      { id: '1', payload: { org: 'llipe', repo: 'memo-cli', domain: 'developer-tools' } },
+      { id: '2', payload: { org: 'llipe', repo: 'memo-cli', domain: 'developer-tools' } },
+      { id: '3', payload: { org: 'acme', repo: 'acme-api', domain: 'infra' } },
+    ]);
+
+    await handleInspect({ json: true }, deps);
+
+    const result = JSON.parse(stdoutData) as Record<string, unknown>;
+    const orgs = result['orgs'] as Array<{ name: string; count: number }>;
+    const repos = result['repos'] as Array<{
+      name: string;
+      org?: string;
+      domain?: string;
+      count: number;
+    }>;
+    const domains = result['domains'] as Array<{ name: string; count: number }>;
+
+    expect(orgs.find((o) => o.name === 'llipe')?.count).toBe(2);
+    expect(orgs.find((o) => o.name === 'acme')?.count).toBe(1);
+
+    const memoCli = repos.find((r) => r.name === 'memo-cli');
+    expect(memoCli?.count).toBe(2);
+    expect(memoCli?.org).toBe('llipe');
+    expect(memoCli?.domain).toBe('developer-tools');
+
+    expect(domains.find((d) => d.name === 'developer-tools')?.count).toBe(2);
+    expect(domains.find((d) => d.name === 'infra')?.count).toBe(1);
+  });
+
+  it('filters to orgs only with --orgs flag', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([
+      { id: '1', payload: { org: 'llipe', repo: 'memo-cli', domain: 'developer-tools' } },
+    ]);
+
+    await handleInspect({ orgs: true }, deps);
+
+    expect(stdoutData).toContain('Organizations (1):');
+    expect(stdoutData).toContain('llipe  (1 entry)');
+    expect(stdoutData).not.toContain('Repositories');
+    expect(stdoutData).not.toContain('Domains');
+  });
+
+  it('filters to repos only with --repos flag', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([
+      { id: '1', payload: { org: 'llipe', repo: 'memo-cli', domain: 'developer-tools' } },
+    ]);
+
+    await handleInspect({ repos: true }, deps);
+
+    expect(stdoutData).toContain('Repositories (1):');
+    expect(stdoutData).toContain('memo-cli  [developer-tools]');
+    expect(stdoutData).not.toContain('Organizations');
+    expect(stdoutData).not.toContain('Domains');
+  });
+
+  it('filters to domains only with --domains flag', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([
+      { id: '1', payload: { org: 'llipe', repo: 'memo-cli', domain: 'developer-tools' } },
+    ]);
+
+    await handleInspect({ domains: true }, deps);
+
+    expect(stdoutData).toContain('Domains (1):');
+    expect(stdoutData).toContain('developer-tools  (1 entry)');
+    expect(stdoutData).not.toContain('Organizations');
+    expect(stdoutData).not.toContain('Repositories');
+  });
+
+  it('outputs --orgs --json with only orgs key', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([
+      { id: '1', payload: { org: 'llipe', repo: 'memo-cli', domain: 'developer-tools' } },
+    ]);
+
+    await handleInspect({ orgs: true, json: true }, deps);
+
+    const result = JSON.parse(stdoutData) as Record<string, unknown>;
+    expect(result['orgs']).toBeDefined();
+    expect(result['repos']).toBeUndefined();
+    expect(result['domains']).toBeUndefined();
+  });
+
+  it('outputs "No entries found." for empty collection', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([]);
+
+    await handleInspect({}, deps);
+
+    expect(stdoutData).toContain('No entries found.');
+  });
+
+  it('handles entries missing some fields gracefully', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([
+      { id: '1', payload: { repo: 'memo-cli' } },
+      { id: '2', payload: { org: 'llipe', domain: 'developer-tools' } },
+      { id: '3', payload: {} },
+    ]);
+
+    await handleInspect({}, deps);
+
+    expect(stdoutData).toContain('Organizations (1):');
+    expect(stdoutData).toContain('Repositories (1):');
+    expect(stdoutData).toContain('Domains (1):');
+  });
+
+  it('scroll is called with no filter (global view)', async () => {
+    mockQdrant.scroll.mockResolvedValueOnce([]);
+
+    await handleInspect({}, deps);
+
+    expect(mockQdrant.scroll).toHaveBeenCalledWith(undefined, 10_000);
+  });
+});

--- a/tests/unit/commands/inspect.test.ts
+++ b/tests/unit/commands/inspect.test.ts
@@ -1,0 +1,226 @@
+import { handleInspect } from '../../../src/commands/inspect.js';
+import type { InspectDeps } from '../../../src/commands/inspect.js';
+import type { MultiFacetResult } from '../../../src/lib/facets.js';
+
+const mockQdrant = {
+  ensureCollection: jest.fn().mockResolvedValue(undefined),
+  scroll: jest.fn().mockResolvedValue([]),
+};
+
+const fullFacets: MultiFacetResult = {
+  orgs: [
+    { name: 'llipe', count: 5 },
+    { name: 'acme', count: 2 },
+  ],
+  repos: [
+    { name: 'memo-cli', org: 'llipe', domain: 'developer-tools', count: 4 },
+    { name: 'platform-docs', org: 'llipe', domain: 'developer-tools', count: 1 },
+    { name: 'acme-api', org: 'acme', count: 2 },
+  ],
+  domains: [
+    { name: 'developer-tools', count: 5 },
+    { name: 'infra', count: 2 },
+  ],
+};
+
+let stdoutData = '';
+
+beforeEach(() => {
+  stdoutData = '';
+  jest.spyOn(process.stdout, 'write').mockImplementation((data: unknown) => {
+    stdoutData += String(data);
+    return true;
+  });
+  jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function makeDeps(facets: MultiFacetResult = fullFacets): InspectDeps {
+  return {
+    createRepo: () => mockQdrant as unknown as ReturnType<NonNullable<InspectDeps['createRepo']>>,
+    aggregate: jest.fn().mockResolvedValue(facets),
+  };
+}
+
+describe('handleInspect', () => {
+  describe('human output (no flags)', () => {
+    it('shows all three sections', async () => {
+      await handleInspect({}, makeDeps());
+
+      expect(stdoutData).toContain('Organizations (2):');
+      expect(stdoutData).toContain('Repositories (3):');
+      expect(stdoutData).toContain('Domains (2):');
+    });
+
+    it('shows orgs with entry counts', async () => {
+      await handleInspect({}, makeDeps());
+
+      expect(stdoutData).toContain('llipe  (5 entries)');
+      expect(stdoutData).toContain('acme  (2 entries)');
+    });
+
+    it('shows repos sorted alpha with domain annotation', async () => {
+      await handleInspect({}, makeDeps());
+
+      expect(stdoutData).toContain('acme-api');
+      expect(stdoutData).toContain('memo-cli  [developer-tools]');
+      expect(stdoutData).toContain('platform-docs  [developer-tools]');
+      expect(stdoutData.indexOf('acme-api')).toBeLessThan(stdoutData.indexOf('memo-cli'));
+    });
+
+    it('shows repos without domain annotation when domain is absent', async () => {
+      await handleInspect({}, makeDeps());
+
+      expect(stdoutData).toContain('acme-api  (2 entries)');
+      expect(stdoutData).not.toContain('acme-api  [');
+    });
+
+    it('shows domains with entry counts', async () => {
+      await handleInspect({}, makeDeps());
+
+      expect(stdoutData).toContain('developer-tools  (5 entries)');
+      expect(stdoutData).toContain('infra  (2 entries)');
+    });
+
+    it('shows singular "entry" for count of 1', async () => {
+      const facets: MultiFacetResult = {
+        orgs: [{ name: 'solo', count: 1 }],
+        repos: [],
+        domains: [],
+      };
+      await handleInspect({}, makeDeps(facets));
+
+      expect(stdoutData).toContain('solo  (1 entry)');
+      expect(stdoutData).not.toContain('1 entries');
+    });
+  });
+
+  describe('facet flag filtering', () => {
+    it('--orgs shows only organizations section', async () => {
+      await handleInspect({ orgs: true }, makeDeps());
+
+      expect(stdoutData).toContain('Organizations (2):');
+      expect(stdoutData).not.toContain('Repositories');
+      expect(stdoutData).not.toContain('Domains');
+    });
+
+    it('--repos shows only repositories section', async () => {
+      await handleInspect({ repos: true }, makeDeps());
+
+      expect(stdoutData).toContain('Repositories (3):');
+      expect(stdoutData).not.toContain('Organizations');
+      expect(stdoutData).not.toContain('Domains');
+    });
+
+    it('--domains shows only domains section', async () => {
+      await handleInspect({ domains: true }, makeDeps());
+
+      expect(stdoutData).toContain('Domains (2):');
+      expect(stdoutData).not.toContain('Organizations');
+      expect(stdoutData).not.toContain('Repositories');
+    });
+  });
+
+  describe('--json output', () => {
+    it('outputs full JSON contract', async () => {
+      await handleInspect({ json: true }, makeDeps());
+
+      const result = JSON.parse(stdoutData) as Record<string, unknown>;
+      expect(result['orgs']).toEqual([
+        { name: 'acme', count: 2 },
+        { name: 'llipe', count: 5 },
+      ]);
+      expect(Array.isArray(result['repos'])).toBe(true);
+      const repos = result['repos'] as Array<Record<string, unknown>>;
+      const memoCli = repos.find((r) => r['name'] === 'memo-cli');
+      expect(memoCli).toEqual({
+        name: 'memo-cli',
+        org: 'llipe',
+        domain: 'developer-tools',
+        count: 4,
+      });
+      expect(result['domains']).toEqual([
+        { name: 'developer-tools', count: 5 },
+        { name: 'infra', count: 2 },
+      ]);
+    });
+
+    it('--orgs --json outputs only orgs', async () => {
+      await handleInspect({ orgs: true, json: true }, makeDeps());
+
+      const result = JSON.parse(stdoutData) as Record<string, unknown>;
+      expect(result['orgs']).toBeDefined();
+      expect(result['repos']).toBeUndefined();
+      expect(result['domains']).toBeUndefined();
+    });
+
+    it('--repos --json includes org and domain for repos', async () => {
+      await handleInspect({ repos: true, json: true }, makeDeps());
+
+      const result = JSON.parse(stdoutData) as Record<string, unknown>;
+      expect(result['repos']).toBeDefined();
+      expect(result['orgs']).toBeUndefined();
+      const repos = result['repos'] as Array<Record<string, unknown>>;
+      const memoCli = repos.find((r) => r['name'] === 'memo-cli');
+      expect(memoCli?.['org']).toBe('llipe');
+      expect(memoCli?.['domain']).toBe('developer-tools');
+    });
+
+    it('repos without org/domain do not include those keys in JSON', async () => {
+      const facets: MultiFacetResult = {
+        orgs: [],
+        repos: [{ name: 'bare-repo', count: 1 }],
+        domains: [],
+      };
+      await handleInspect({ repos: true, json: true }, makeDeps(facets));
+
+      const result = JSON.parse(stdoutData) as Record<string, unknown>;
+      const repos = result['repos'] as Array<Record<string, unknown>>;
+      expect(repos[0]).toEqual({ name: 'bare-repo', count: 1 });
+      expect(repos[0]?.['org']).toBeUndefined();
+      expect(repos[0]?.['domain']).toBeUndefined();
+    });
+  });
+
+  describe('empty result', () => {
+    const emptyFacets: MultiFacetResult = { orgs: [], repos: [], domains: [] };
+
+    it('outputs "No entries found." message', async () => {
+      await handleInspect({}, makeDeps(emptyFacets));
+
+      expect(stdoutData).toContain('No entries found.');
+    });
+
+    it('outputs "No entries found." even with facet flag', async () => {
+      await handleInspect({ orgs: true }, makeDeps(emptyFacets));
+
+      expect(stdoutData).toContain('No entries found.');
+    });
+
+    it('does not output JSON when empty', async () => {
+      await handleInspect({ json: true }, makeDeps(emptyFacets));
+
+      expect(stdoutData).toContain('No entries found.');
+      expect(() => JSON.parse(stdoutData)).toThrow();
+    });
+  });
+
+  describe('aggregate call', () => {
+    it('calls aggregate with scroll function and no filter', async () => {
+      const mockAggregate = jest.fn().mockResolvedValue(fullFacets);
+      const deps: InspectDeps = {
+        createRepo: () =>
+          mockQdrant as unknown as ReturnType<NonNullable<InspectDeps['createRepo']>>,
+        aggregate: mockAggregate,
+      };
+
+      await handleInspect({}, deps);
+
+      expect(mockAggregate).toHaveBeenCalledWith(expect.any(Function));
+    });
+  });
+});


### PR DESCRIPTION
## What

Implements the `memo inspect` command (Issue #19) — a global facet browser that shows unique organizations, repositories, and domains with their entry counts.

## Why

Closes #19

Enables users (and agents) to quickly understand the scope of the memo knowledge base across all repos without needing a specific repo context.

## How

- **Extended `src/lib/facets.ts`** with `aggregateMultipleFields()` — scrolls all entries once and simultaneously accumulates `org`, `repo`, and `domain` counts. For repos, the first observed `org` and `domain` values are captured to enrich JSON output.
- **Created `src/commands/inspect.ts`** — `memo inspect` command:
  - Flags: `--orgs`, `--repos`, `--domains` (filter to a single facet), `--json`
  - No repo filter — global view of entire collection
  - Human output: grouped sections `Organizations (N):`, `Repositories (N):`, `Domains (N):` with name/count; repos show `[domain]` annotation when available
  - JSON output: `{ orgs, repos, domains }` with enriched repo entries (`name`, `org?`, `domain?`, `count`)
  - Empty result: exit 0 with `"No entries found."` message
- **Registered** `memo inspect` in `src/index.ts`

## Testing

- `tests/unit/commands/inspect.test.ts` — 23 unit tests covering: human output, facet flags, `--json` contract, empty results, aggregate call signature
- `tests/integration/commands/inspect.test.ts` — 9 integration tests covering: full aggregation, JSON contract, all facet flags, empty collection, partial-field entries, scroll called globally

## Checklist

- [x] TypeScript compiles clean (`pnpm typecheck`)
- [x] ESLint passes (`pnpm lint`)
- [x] Tests pass — 35 tests, 3 suites (`pnpm test -- --testPathPattern="inspect|facets"`)
