### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "author": "llipe",
   "license": "MIT",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/llipe/memo-cli"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Include the repository field in package.json to specify the project's GitHub repository.