### PR TITLE
Enhance memo-cli-usage skill documentation and add environment variable

### DIFF
--- a/.github/skills/memo-cli-usage/SKILL.md
+++ b/.github/skills/memo-cli-usage/SKILL.md
@@ -87,6 +87,61 @@ memo setup show       # print effective config
 
 ## Core Concepts
 
+### `repo` — Repository Identity
+
+`repo` is the **name of the codebase** this entry belongs to. It is set in `memo.config.json` and defaults into every `memo write` call automatically. Use the kebab-case name of the Git repository (e.g., `memo-cli`, `auth-service`, `api-gateway`).
+
+**Why it matters:** Every entry is scoped to a repo. `memo search` and `memo list` filter by your current repo by default, so entries from other repos don't pollute your results unless you explicitly request them with `--scope related`.
+
+**Rule:** Use the repo's canonical name — the one that appears in the GitHub URL. Don't abbreviate or alias it.
+
+---
+
+### `org` — Organization
+
+`org` is the **owner or organization** that the repository belongs to. In GitHub terms, this is the account or org username (e.g., `llipe`, `acme-corp`, `my-team`).
+
+**Why it matters:** `org` groups related repositories under a common owner. It enables cross-repo queries scoped to a single organization — e.g., finding all decisions made under `acme-corp` across all its services.
+
+**Rule:** Use the GitHub organization or user handle, kebab-case. All repos under the same team should share the same `org` value.
+
+---
+
+### `domain` — Product or Functional Area
+
+`domain` describes the **product area or functional concern** that this repository serves (e.g., `auth`, `payments`, `infra`, `ai`, `search`, `notifications`). It is broader than a repository — multiple repos can share the same domain.
+
+**Why it matters:** Domain is a cross-cutting label that lets you query decisions across all repos in a functional area. For example, all `auth`-domain decisions across `auth-service`, `api-gateway`, and `user-service` can be retrieved together.
+
+**How to choose:**
+- Use the business or technical capability, not the team name.
+- Keep it stable — domains change less often than repos.
+- Examples: `auth`, `billing`, `data-pipeline`, `mobile`, `platform`, `ai`, `infra`, `developer-tools`.
+
+---
+
+### `relates_to` — Connected Repositories
+
+`relates_to` is an **explicit list of other repository names** that this repo has a meaningful relationship with — shared contracts, shared schemas, upstream/downstream dependencies, or simply repos that an agent often works across together.
+
+```json
+{
+  "relates_to": ["auth-service", "api-gateway", "shared-lib"]
+}
+```
+
+**Why it matters:** Setting `relates_to` enables `--scope related` queries, which search entries across this repo **and** all listed repos simultaneously. This is how agents and developers get cross-service context without switching repositories.
+
+**When to add a repo to `relates_to`:**
+- This repo consumes an API or event contract that the other repo owns.
+- Decisions in the other repo often directly constrain decisions in this one.
+- You regularly need to cross-reference both repos during feature work.
+- They share a data model or schema.
+
+**Rule:** Keep `relates_to` intentional — list real dependencies, not every repo in the org. A bloated list degrades search signal.
+
+---
+
 ### Entry Types
 
 | Type | When to use |

--- a/.github/skills/memo-cli-usage/SKILL.md
+++ b/.github/skills/memo-cli-usage/SKILL.md
@@ -1,0 +1,401 @@
+# memo-cli Usage Skill
+
+Teach AI agents (and human developers) how to operate **memo-cli** — the agent-first CLI for capturing and querying architectural decisions stored in a shared Qdrant vector database.
+
+Use this skill whenever an agent needs to **read**, **write**, **search**, or **manage** decision entries in a repository that has `memo-cli` installed.
+
+> **Portability:** This skill is self-contained. Copy the `memo-cli-usage/` folder into any repository's `.github/skills/` directory and reference it from that repo's `AGENTS.md` or skill registry.
+
+---
+
+## When to Use
+
+- Recording an architectural decision, integration point, or structural choice during implementation.
+- Searching for prior decisions before making a new one (avoid contradictions / duplicates).
+- Listing recent entries to build context at the start of a session.
+- Onboarding a new agent or developer to the decision history of a repository.
+- Cleaning up outdated or incorrect entries.
+- Discovering which organizations, repositories, or domains exist in the shared knowledge base.
+
+---
+
+## Prerequisites
+
+### Environment Variables
+
+The following variables **MUST** be set before any `memo` command will work:
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `QDRANT_URL` | Qdrant instance endpoint | `http://localhost:6333` |
+| `QDRANT_API_KEY` | API key (empty for local) | `""` or a cloud key |
+| `EMBEDDINGS_PROVIDER` | Embedding backend | `openai` |
+| `EMBEDDINGS_API_KEY` | Provider secret key | `sk-...` |
+
+> **Tip:** Store these in a `.env` file at the repository root. `memo-cli` loads it automatically via `dotenv`.
+
+### Repository Configuration
+
+A `memo.config.json` **MUST** exist at the repository root. Create one with:
+
+```bash
+memo setup init --repo <repo-name> --org <org-name> --domain <domain> [--relates-to repo1,repo2]
+```
+
+Verify it at any time:
+
+```bash
+memo setup validate   # exit 0 = valid
+memo setup show       # print effective config
+```
+
+---
+
+## Core Concepts
+
+### Entry Types
+
+| Type | When to use |
+|------|-------------|
+| `decision` | Architectural or design choices ("We chose Postgres over Mongo because…") |
+| `integration_point` | Cross-service contracts, API boundaries, shared schemas |
+| `structure` | Folder layout, module boundaries, naming conventions |
+
+### Source
+
+| Value | Meaning |
+|-------|---------|
+| `agent` | Written by an AI agent (default when `defaults.source` is set) |
+| `manual` | Written by a human developer |
+
+### Scoping
+
+Every entry belongs to a **repo**, **org**, and **domain** (all kebab-case). Queries default to the current repo context from `memo.config.json`.
+
+- `--scope repo` — Only entries for the current repository.
+- `--scope related` — Current repository + all repos listed in `relates_to`.
+
+---
+
+## Command Reference
+
+### `memo write` — Record a Decision
+
+```bash
+memo write \
+  --rationale "Chose JWT over session cookies for stateless auth across services" \
+  --tags "auth,jwt,stateless" \
+  --entry-type decision \
+  --source agent \
+  --json
+```
+
+**Required flags:**
+- `--rationale` — The decision text (1–5 000 chars).
+- `--tags` — 2–5 comma-separated kebab-case tags.
+
+**Optional flags:**
+- `--entry-type` — `decision` (default) | `integration_point` | `structure`
+- `--source` — `agent` | `manual` (falls back to config default)
+- `--commit` — Git commit SHA for traceability
+- `--story` — Story or task ID
+- `--files` — Comma-separated file paths touched by the decision
+- `--relates-to` — Related repo names
+- `--on-duplicate` — `consolidate` | `update` | `replace` | `create-new`
+- `--json` — Machine-readable output (**always use in agent mode**)
+
+**Duplicate handling:**
+When memo detects a duplicate (same `repo + commit + story + entry_type + source`), interactive mode prompts for resolution. In `--json` mode you **MUST** supply `--on-duplicate` or the command will fail.
+
+---
+
+### `memo search` — Semantic Search
+
+```bash
+memo search "rate limiting strategy" --limit 5 --json
+```
+
+Natural-language vector search over decision entries.
+
+**Optional flags:**
+- `--scope` — `repo` (default) | `related`
+- `--tags` — Comma-separated filter (AND logic)
+- `--entry-type` — Filter by type
+- `--source` — Filter by source
+- `--limit` — Max results (default 10)
+- `--json` — Machine-readable output
+
+---
+
+### `memo list` — Chronological Browse
+
+```bash
+memo list --limit 20 --json
+```
+
+Most-recent-first listing with optional date range.
+
+**Optional flags:**
+- `--scope`, `--tags`, `--entry-type`, `--source` — Same as search
+- `--from` / `--to` — ISO 8601 date boundaries
+- `--limit` — Max results (default 20)
+- `--json` — Machine-readable output
+
+---
+
+### `memo tags list` — Discover Tags
+
+```bash
+memo tags list --sort frequency --json
+```
+
+Shows all unique tags with entry counts.
+
+**Optional flags:**
+- `--scope` — `repo` | `related`
+- `--sort` — `alpha` (default) | `frequency`
+- `--json` — Machine-readable output
+
+---
+
+### `memo inspect` — Global Facet Discovery
+
+```bash
+memo inspect --json
+```
+
+Lists all organizations, repositories, and domains across the entire knowledge base (ignores repo scope). Useful for onboarding and cross-team exploration.
+
+**Optional flags:**
+- `--orgs` / `--repos` / `--domains` — Show only one facet
+- `--json` — Machine-readable output
+
+---
+
+### `memo delete` — Remove Entries
+
+**Single entry:**
+```bash
+memo delete --id <uuid> --json
+```
+
+**Bulk (interactive only — blocked in `--json` mode for safety):**
+```bash
+memo delete --all-by-repo <repo-name> --yes
+memo delete --all-by-org <org-name> --yes
+```
+
+Exactly one of `--id`, `--all-by-repo`, or `--all-by-org` is required.
+
+---
+
+## Agent Workflows
+
+### Starting a Session — Build Context
+
+At the **beginning of every coding session**, an agent SHOULD run this sequence to understand the current decision landscape:
+
+```bash
+# 1. Verify config is valid
+memo setup validate
+
+# 2. See what's in the knowledge base
+memo inspect --json
+
+# 3. List recent decisions for this repo
+memo list --limit 10 --json
+
+# 4. Check the tag landscape
+memo tags list --sort frequency --json
+
+# 5. Search for anything relevant to the current task
+memo search "<current task description>" --limit 5 --json
+```
+
+### During Implementation — Record Decisions
+
+Whenever a non-trivial architectural or design choice is made:
+
+```bash
+memo write \
+  --rationale "Describe the decision and the reasoning behind it" \
+  --tags "relevant,tags,here" \
+  --entry-type decision \
+  --source agent \
+  --commit "$(git rev-parse HEAD)" \
+  --story "TASK-123" \
+  --files "src/auth/jwt.ts,src/middleware/auth.ts" \
+  --json
+```
+
+**What makes a good decision entry:**
+- Captures the **why**, not just the **what**.
+- Includes enough context that a different agent or developer can understand the rationale months later.
+- Links to the commit and story/task for traceability.
+- Uses precise, descriptive tags for discoverability.
+
+### Before Making a Decision — Search First
+
+Before committing to a design choice, **always search** for prior relevant decisions:
+
+```bash
+memo search "authentication middleware approach" --scope related --json
+```
+
+This prevents contradictions with existing decisions and surfaces patterns already established in related repositories.
+
+### End of Session — Summarize
+
+If significant decisions were made, consider writing a summary entry:
+
+```bash
+memo write \
+  --rationale "Session summary: implemented rate-limiting with token-bucket algorithm, chose Redis for counter storage due to TTL support" \
+  --tags "rate-limiting,redis,session-summary" \
+  --entry-type decision \
+  --source agent \
+  --json
+```
+
+---
+
+## Multi-Developer & Cross-Session Context
+
+`memo-cli` is designed so that **every agent and developer shares the same decision history**. This is what makes it valuable in teams:
+
+### Shared Knowledge Base
+
+All entries are stored in a shared Qdrant instance. When Developer A records a decision, Developer B (or Agent B) can immediately find it via `memo search` or `memo list`. There is no per-user silo.
+
+### Cross-Repository Visibility
+
+Use `--scope related` alongside the `relates_to` configuration to query decisions from connected repositories. This is critical for:
+- Microservice architectures where contracts span repos.
+- Monorepo-adjacent setups where domain boundaries cross packages.
+
+### Session Continuity for Agents
+
+Agents are stateless between sessions. To maintain continuity:
+
+1. **Start every session** with `memo list` and `memo search` to load prior context.
+2. **End every session** by writing any significant decisions made.
+3. **Tag consistently** — use the same tag vocabulary across sessions so future searches find related entries. Run `memo tags list` to see what tags already exist before inventing new ones.
+
+### What to Record (Guidelines)
+
+| Record | Skip |
+|--------|------|
+| Architectural choices and their rationale | Trivial implementation details |
+| Technology selections with trade-off analysis | Routine bug fixes |
+| API contracts and integration boundaries | Formatting or style preferences (use linters) |
+| Data model decisions | Temporary workarounds (unless they become permanent) |
+| Security-sensitive design choices | Build/CI configuration (use config files) |
+| Performance trade-offs | Dependency version bumps |
+
+---
+
+## Memory Scopes (IDE / Agent Memory vs. memo-cli)
+
+Many agent runtimes (e.g., VS Code Copilot) have a built-in memory system alongside `memo-cli`. Understanding when to use each is key:
+
+| Scope | Path | Persistence | Use For |
+|-------|------|-------------|---------|
+| **User memory** | `/memories/` | Across all workspaces & sessions | Personal preferences, debugging patterns, general insights |
+| **Session memory** | `/memories/session/` | Current conversation only | Task-specific scratch notes, in-progress state |
+| **Repository memory** | `/memories/repo/` | Current workspace | Repo-specific facts: build commands, conventions, gotchas |
+| **memo-cli** | Qdrant (shared) | Permanent, shared across all agents & developers | Architectural decisions, integration points, structural choices |
+
+### Decision Tree: Where to Store Information
+
+1. **Is it an architectural decision, design rationale, or integration contract?** → `memo write`
+2. **Is it a repo-specific convention or gotcha that all agents should know?** → `/memories/repo/` AND consider `memo write` if it reflects an architectural choice
+3. **Is it a personal preference or general pattern?** → `/memories/` (user memory)
+4. **Is it temporary, in-progress context for this session only?** → `/memories/session/`
+
+---
+
+## Safe Operation Guardrails
+
+### Non-Destructive Defaults
+
+- `memo delete` requires confirmation by default. Use `--yes` to skip only when you are certain.
+- Bulk delete (`--all-by-repo`, `--all-by-org`) is **blocked in `--json` mode** as a safety guard against accidental mass deletion by agents.
+- `memo write` detects duplicates and prompts for resolution rather than silently overwriting.
+
+### Agent Mode (`--json`)
+
+Agents **SHOULD** always pass `--json` for predictable, parseable output. Key behaviors in JSON mode:
+- All output is structured JSON on stdout.
+- Errors produce JSON error objects to stderr.
+- Interactive prompts are suppressed — flags must supply all decisions.
+- `--on-duplicate` is required when a duplicate is detected.
+- Bulk delete is prohibited.
+
+### Validation Before Writing
+
+Before `memo write`, agents SHOULD:
+1. Verify `memo setup validate` passes.
+2. Confirm tags are kebab-case (lowercase, hyphens only).
+3. Ensure rationale is meaningful (not placeholder text).
+4. Check for duplicates with `memo search` first.
+
+### Error Handling
+
+All `memo` commands exit with:
+- **0** — Success
+- **1** — Validation or user error (bad flags, invalid config)
+- **2** — Unexpected/infrastructure error (Qdrant down, embedding API failure)
+
+When a command fails:
+1. Read the error code and message from stderr.
+2. For exit code 1: fix the input and retry.
+3. For exit code 2: check connectivity (`QDRANT_URL`) and API keys before retrying.
+
+### Environment Variable Safety
+
+- **Never** log or output `EMBEDDINGS_API_KEY` or `QDRANT_API_KEY`.
+- Store credentials in `.env` (which should be in `.gitignore`).
+- For CI/CD, use secrets management rather than plaintext config.
+
+---
+
+## Quick Reference Card
+
+```
+memo setup init --repo <r> --org <o> --domain <d>   # Initialize config
+memo setup validate                                   # Verify config
+memo setup show [--json]                              # Display config
+
+memo write --rationale "..." --tags "a,b,c" [--json]  # Record decision
+memo search "query" [--scope related] [--json]         # Semantic search
+memo list [--from DATE] [--to DATE] [--json]           # Browse entries
+memo tags list [--sort frequency] [--json]             # Discover tags
+memo inspect [--json]                                  # Global facets
+memo delete --id <uuid> [--json]                       # Delete entry
+```
+
+---
+
+## Installation in Another Repository
+
+1. **Copy** the `memo-cli-usage/` folder into `<your-repo>/.github/skills/`.
+2. **Add** the skill to your agent/skill registry (e.g., `AGENTS.md`):
+   ```markdown
+   | memo-cli-usage | `.github/skills/memo-cli-usage/` | Agent guidance for memo-cli operations | Any agent |
+   ```
+3. **Install** `memo-cli` as a dev dependency:
+   ```bash
+   pnpm add -D memo-cli   # or npm install -D memo-cli
+   ```
+4. **Configure** the repository:
+   ```bash
+   npx memo setup init --repo <name> --org <org> --domain <domain>
+   ```
+5. **Set** environment variables (`.env` or CI secrets):
+   ```
+   QDRANT_URL=http://localhost:6333
+   QDRANT_API_KEY=
+   EMBEDDINGS_PROVIDER=openai
+   EMBEDDINGS_API_KEY=sk-...
+   ```
+6. The skill is now active — any agent that loads it will know how to use `memo-cli`.

--- a/.github/skills/memo-cli-usage/SKILL.md
+++ b/.github/skills/memo-cli-usage/SKILL.md
@@ -8,14 +8,48 @@ Use this skill whenever an agent needs to **read**, **write**, **search**, or **
 
 ---
 
-## When to Use
+## Purpose
 
-- Recording an architectural decision, integration point, or structural choice during implementation.
-- Searching for prior decisions before making a new one (avoid contradictions / duplicates).
-- Listing recent entries to build context at the start of a session.
-- Onboarding a new agent or developer to the decision history of a repository.
-- Cleaning up outdated or incorrect entries.
-- Discovering which organizations, repositories, or domains exist in the shared knowledge base.
+`memo-cli` is the **shared memory** that keeps agents coherent across time, sessions, and projects. It is not a log. It is not a changelog. It is a curated, searchable record of the decisions that shaped the codebase — written with enough precision that anyone (human or agent) arriving days, weeks, or months later can understand **what was decided, why, and what it affected**.
+
+An agent that uses `memo-cli` well:
+- Narrates its reasoning as it acts, not only at the end.
+- Records the files it modifies and why those files were the right place.
+- Explains configuration and architectural choices so future agents don't re-derive them.
+- Tags entries consistently so discovery remains reliable across projects.
+
+---
+
+## When to Write to memo-cli
+
+Write a memo entry **during** or **immediately after** any of these moments:
+
+| Trigger | Entry Type |
+|---------|-----------|
+| Choosing a library, framework, or service | `decision` |
+| Choosing how to structure a module or data model | `decision` / `structure` |
+| Changing a config file and explaining why | `decision` |
+| Identifying or formalizing a cross-service contract | `integration_point` |
+| Modifying critical files (entry points, core abstractions, schema) | `decision` |
+| Discovering a constraint (API limit, platform quirk, security requirement) | `decision` |
+| Resolving a conflict between two approaches | `decision` |
+| Establishing a naming or layout convention | `structure` |
+| Starting work on a story or task (intent entry) | `decision` |
+| Completing a story or task (outcome entry) | `decision` |
+
+---
+
+## When to Search memo-cli
+
+Search **before** taking action, not only when stuck:
+
+| Situation | Command |
+|-----------|---------|
+| Starting a session — restore context | `memo list --limit 20 --json` |
+| Before making a design choice | `memo search "<topic>" --json` |
+| Before touching a file you haven't seen before | `memo search "<filename or module name>" --json` |
+| Evaluating whether to add a dependency | `memo search "<library name>" --scope related --json` |
+| Onboarding to an unfamiliar repo | `memo inspect --json` then `memo list --json` |
 
 ---
 
@@ -191,126 +225,323 @@ Exactly one of `--id`, `--all-by-repo`, or `--all-by-org` is required.
 
 ## Agent Workflows
 
-### Starting a Session — Build Context
+### Starting a Session — Restore Context
 
-At the **beginning of every coding session**, an agent SHOULD run this sequence to understand the current decision landscape:
+At the **beginning of every session**, run this sequence before writing a single line of code:
 
 ```bash
-# 1. Verify config is valid
+# 1. Confirm config is valid
 memo setup validate
 
-# 2. See what's in the knowledge base
+# 2. Discover what repos/orgs/domains exist
 memo inspect --json
 
-# 3. List recent decisions for this repo
-memo list --limit 10 --json
+# 3. Review recent decisions for this repo
+memo list --limit 20 --json
 
-# 4. Check the tag landscape
+# 4. Check the established tag vocabulary
 memo tags list --sort frequency --json
 
-# 5. Search for anything relevant to the current task
-memo search "<current task description>" --limit 5 --json
+# 5. Search for context relevant to the current task
+memo search "<current task or feature description>" --limit 10 --json
 ```
 
-### During Implementation — Record Decisions
+Read the results before proceeding. Prior entries may contain constraints, preferred patterns, or rejected alternatives that directly affect how you should approach the current task.
 
-Whenever a non-trivial architectural or design choice is made:
+---
 
+### Recording Decisions — As You Work, Not Only at the End
+
+Write a memo entry **at the moment you make a decision**, not as a post-hoc summary. This preserves the full reasoning before context is lost.
+
+**Template:**
 ```bash
 memo write \
-  --rationale "Describe the decision and the reasoning behind it" \
-  --tags "relevant,tags,here" \
+  --rationale "CONTEXT. DECISION. RATIONALE." \
+  --tags "tag1,tag2,tag3" \
   --entry-type decision \
   --source agent \
   --commit "$(git rev-parse HEAD)" \
-  --story "TASK-123" \
-  --files "src/auth/jwt.ts,src/middleware/auth.ts" \
+  --story "ISSUE-42" \
+  --files "path/to/file1.ts,path/to/file2.ts" \
   --json
 ```
 
-**What makes a good decision entry:**
-- Captures the **why**, not just the **what**.
-- Includes enough context that a different agent or developer can understand the rationale months later.
-- Links to the commit and story/task for traceability.
-- Uses precise, descriptive tags for discoverability.
+The `--rationale` field is the most important field. See **Writing Quality** below.
 
-### Before Making a Decision — Search First
+---
 
-Before committing to a design choice, **always search** for prior relevant decisions:
+### Recording File Changes — Explain the Why
 
-```bash
-memo search "authentication middleware approach" --scope related --json
-```
-
-This prevents contradictions with existing decisions and surfaces patterns already established in related repositories.
-
-### End of Session — Summarize
-
-If significant decisions were made, consider writing a summary entry:
+When modifying a significant file (entry point, core abstraction, schema, config), record what changed and why:
 
 ```bash
 memo write \
-  --rationale "Session summary: implemented rate-limiting with token-bucket algorithm, chose Redis for counter storage due to TTL support" \
-  --tags "rate-limiting,redis,session-summary" \
+  --rationale "Modified src/lib/config.ts to add schema_version validation. The config loader previously accepted any object; adding Zod validation ensures CLI commands fail fast on malformed configs rather than producing silent errors downstream." \
+  --tags "config,validation,config-ts,error-handling" \
+  --entry-type decision \
+  --source agent \
+  --commit "$(git rev-parse HEAD)" \
+  --files "src/lib/config.ts,src/types/config.ts" \
+  --json
+```
+
+---
+
+### Recording Configuration Decisions
+
+Configuration decisions are especially important to preserve — they often appear opaque later with no obvious rationale in the code.
+
+```bash
+memo write \
+  --rationale "Set QDRANT_COLLECTION_NAME to 'decisions' permanently rather than making it configurable. A single collection per deployment simplifies queries and access control. Multi-tenancy is achieved via repo/org payload fields, not separate collections. Reconsidering this would require a data migration." \
+  --tags "qdrant,config,multi-tenancy,collection-design" \
   --entry-type decision \
   --source agent \
   --json
+```
+
+Configuration decisions to always record:
+- Environment variable semantics (what the value controls, valid ranges, defaults)
+- Feature flags and their trigger conditions
+- Schema versions and migration policies
+- Storage layout choices (collection names, index strategies, partitioning)
+- Security-related configuration (TLS, auth, CORS, rate limits)
+
+---
+
+### Intent Entry — Narrate Before Acting
+
+For significant tasks, write an **intent entry** before starting implementation. This creates a checkpoint that future sessions can find, and anchors the rationale for every decision that follows.
+
+```bash
+memo write \
+  --rationale "Starting implementation of story ISSUE-37: safe delete command. Approach: add a --yes flag for non-interactive confirmation, block --json with bulk delete flags (safety guard for agents), preview affected entries before deletion. No soft-delete; permanent removal via Qdrant point deletion. This matches the existing write/search command pattern." \
+  --tags "delete,safety,issue-37,intent" \
+  --entry-type decision \
+  --source agent \
+  --story "ISSUE-37" \
+  --json
+```
+
+---
+
+### Outcome Entry — Summarize After Completing
+
+When finishing a task, write an **outcome entry** that captures what actually happened vs. what was intended:
+
+```bash
+memo write \
+  --rationale "Completed ISSUE-37 safe delete command. Shipped: --id single delete, --all-by-repo and --all-by-org bulk delete (interactive only), --yes to skip confirm, preview before deletion. Deviation from intent: bulk delete also disallowed with --json (not just flagged) after discovering Qdrant batch delete has no confirmation step. Modified: src/commands/delete.ts (new), tests/unit/commands/delete.test.ts (new)." \
+  --tags "delete,safety,issue-37,outcome" \
+  --entry-type decision \
+  --source agent \
+  --story "ISSUE-37" \
+  --files "src/commands/delete.ts,tests/unit/commands/delete.test.ts" \
+  --json
+```
+
+---
+
+## Writing Quality
+
+The `--rationale` field must be **precise enough that a different developer or agent — with no prior context — can understand what was decided, why, and what it affects.** A good entry answers three questions:
+
+1. **Context** — What is the situation, constraint, or problem?
+2. **Decision** — What was chosen or done?
+3. **Rationale** — Why this choice over the alternatives?
+
+### Good vs. Bad Examples
+
+**Too vague — useless to a future reader:**
+> "Updated auth to use JWT."
+
+**Precise — useful across sessions and developers:**
+> "Switched authentication from server-side sessions to JWT (HS256, 15-min access + 7-day refresh). Sessions required sticky routing which is incompatible with the planned horizontal scaling. JWTs are stateless — any instance can validate without a shared session store. Trade-off: revocation requires a Redis blacklist (added to ISSUE-51 backlog). Files: src/auth/jwt.ts, src/middleware/auth.ts."
+
+---
+
+**Too vague:**
+> "Changed config validation."
+
+**Precise:**
+> "Added Zod validation to memo.config.json loader (src/lib/config.ts). Previously the code trusted the file's shape; malformed configs caused cryptic runtime errors deep in Qdrant queries. Now the CLI fails immediately at startup with a structured error message. This is the single place config is read — no other validation needed."
+
+---
+
+**Too vague:**
+> "Used Redis for caching."
+
+**Precise:**
+> "Chose Redis (via ioredis) over in-process LRU cache for rate-limit counters. In-process cache doesn't survive pod restarts and is not shared across replicas. Redis TTL natively aligns with the sliding window algorithm. Accepted dependency: Redis must be available in all environments. Config: REDIS_URL env var, no auth in dev, TLS required in prod."
+
+---
+
+### Structural Rule
+
+Write `--rationale` as a single coherent paragraph (or 2-3 short sentences). **Avoid bullet points** in the rationale field — they fragment reasoning and lose connective logic. Save structure for tags.
+
+Minimum viable rationale: **context sentence + decision sentence + why sentence**.
+
+---
+
+## Tag Strategy
+
+Tags are the primary way to discover entries. Good tagging makes the difference between a searchable knowledge base and an unsearchable archive.
+
+### Tag Layers
+
+Apply tags across **multiple layers** simultaneously:
+
+| Layer | Purpose | Examples |
+|-------|---------|---------|
+| **Domain/feature** | What area of the system | `auth`, `rate-limiting`, `config`, `delete`, `storage` |
+| **Technology** | What tech is involved | `qdrant`, `redis`, `openai`, `zod`, `jwt` |
+| **Entry nature** | What kind of change | `intent`, `outcome`, `constraint`, `trade-off`, `adr` |
+| **Story/task ref** | Traceability | `issue-37`, `story-s003`, `prd-001` |
+| **Scope** | How broad the impact | `cross-repo`, `breaking-change`, `config-change` |
+
+Every write SHOULD include tags from at least **2–3 layers**.
+
+### Before Inventing a Tag — Check What Exists
+
+```bash
+memo tags list --sort frequency --json
+```
+
+Re-use existing tags whenever possible. Consistent vocabulary is what allows `memo search` to surface related entries from weeks ago or from a different repository.
+
+### Tag Naming Rules
+
+- Kebab-case only: `rate-limiting`, not `rateLimiting` or `rate_limiting`.
+- Prefer specific over generic: `qdrant-collection` over `database`.
+- For story/task refs: `issue-37`, `story-s003` (numeric, no spaces).
+- Session markers: `intent` (beginning of task) and `outcome` (completion).
+- For cross-cutting concerns: `breaking-change`, `security`, `performance`, `config-change`.
+
+### Tag Examples by Scenario
+
+**Architectural decision on storage:**
+```
+qdrant,collection-design,multi-tenancy,decision,adr
+```
+
+**Config change:**
+```
+config,env-vars,config-change,issue-42
+```
+
+**Integration contract between two services:**
+```
+api-contract,auth-service,cross-repo,integration-point,breaking-change
+```
+
+**Starting a new feature (intent):**
+```
+delete-command,safety,issue-37,intent
+```
+
+**Completing a feature (outcome):**
+```
+delete-command,safety,issue-37,outcome
+```
+
+**Performance trade-off:**
+```
+embeddings,openai,performance,trade-off,caching
 ```
 
 ---
 
 ## Multi-Developer & Cross-Session Context
 
-`memo-cli` is designed so that **every agent and developer shares the same decision history**. This is what makes it valuable in teams:
+`memo-cli` is designed so that **every agent and every developer shares the same decision history**. This is what enables continuity across days, team rotations, and parallel workstreams.
 
 ### Shared Knowledge Base
 
-All entries are stored in a shared Qdrant instance. When Developer A records a decision, Developer B (or Agent B) can immediately find it via `memo search` or `memo list`. There is no per-user silo.
+All entries are stored in a shared Qdrant instance. When Developer A (or Agent A) records a decision, Developer B can immediately find it via `memo search`. There is no per-user silo.
 
 ### Cross-Repository Visibility
 
-Use `--scope related` alongside the `relates_to` configuration to query decisions from connected repositories. This is critical for:
+Use `--scope related` to query across connected repositories:
+
+```bash
+memo search "auth contract" --scope related --json
+```
+
+This is critical for:
 - Microservice architectures where contracts span repos.
-- Monorepo-adjacent setups where domain boundaries cross packages.
+- Agent workflows that touch multiple repositories in sequence.
+- Detecting when a decision in one repo contradicts a constraint in another.
+
+Configure related repos in `memo.config.json`:
+```json
+{
+  "relates_to": ["auth-service", "api-gateway", "shared-lib"]
+}
+```
 
 ### Session Continuity for Agents
 
 Agents are stateless between sessions. To maintain continuity:
 
-1. **Start every session** with `memo list` and `memo search` to load prior context.
-2. **End every session** by writing any significant decisions made.
-3. **Tag consistently** — use the same tag vocabulary across sessions so future searches find related entries. Run `memo tags list` to see what tags already exist before inventing new ones.
+1. **Start every session** with `memo list` and `memo search` — always.
+2. **Write an intent entry** before starting significant work.
+3. **Write as you decide**, not as a batch at the end.
+4. **Write an outcome entry** when completing a task, including any deviations from intent.
+5. **Tag consistently** — check `memo tags list` before picking tags.
 
-### What to Record (Guidelines)
+### Multi-Day Work Pattern
+
+For work that spans multiple days:
+
+- **Day 1 end**: Write an outcome entry with current state, what's done, what's next, any open questions.
+- **Day 2 start**: `memo search "<task name or issue number>" --json` to restore exact context.
+- The tags `intent` and `outcome` combined with a story tag (e.g., `issue-37`) make the full arc of a feature retrievable as a timeline.
+
+### What to Record vs. What to Skip
 
 | Record | Skip |
 |--------|------|
-| Architectural choices and their rationale | Trivial implementation details |
-| Technology selections with trade-off analysis | Routine bug fixes |
-| API contracts and integration boundaries | Formatting or style preferences (use linters) |
-| Data model decisions | Temporary workarounds (unless they become permanent) |
-| Security-sensitive design choices | Build/CI configuration (use config files) |
-| Performance trade-offs | Dependency version bumps |
+| Architectural choices and their rationale | Trivial implementation details (variable names, formatting) |
+| Technology selections with trade-off analysis | Routine bug fixes with no design impact |
+| Configuration changes that affect behavior | Code style choices (use linters) |
+| API contracts and integration boundaries | Dependency version bumps (use lockfile) |
+| Security-sensitive design choices | Temporary workarounds expected to be removed within hours |
+| Performance trade-offs and their context | Generated code |
+| Rejected alternatives and why | CI/build configuration (use config files) |
+| Constraints discovered during implementation | Debugging steps |
 
 ---
 
 ## Memory Scopes (IDE / Agent Memory vs. memo-cli)
 
-Many agent runtimes (e.g., VS Code Copilot) have a built-in memory system alongside `memo-cli`. Understanding when to use each is key:
+Many agent runtimes (e.g., VS Code Copilot) have a built-in memory system alongside `memo-cli`. Understanding when to use each prevents both redundancy and gaps.
 
-| Scope | Path | Persistence | Use For |
-|-------|------|-------------|---------|
-| **User memory** | `/memories/` | Across all workspaces & sessions | Personal preferences, debugging patterns, general insights |
-| **Session memory** | `/memories/session/` | Current conversation only | Task-specific scratch notes, in-progress state |
-| **Repository memory** | `/memories/repo/` | Current workspace | Repo-specific facts: build commands, conventions, gotchas |
-| **memo-cli** | Qdrant (shared) | Permanent, shared across all agents & developers | Architectural decisions, integration points, structural choices |
+| Scope | Where | Persistence | Use For |
+|-------|-------|-------------|---------|
+| **User memory** | `/memories/` | All workspaces, all sessions | Personal preferences, debugging patterns, general agent insights |
+| **Session memory** | `/memories/session/` | Current conversation only | Scratch notes, in-progress state, temporary checklists |
+| **Repository memory** | `/memories/repo/` | Current workspace | Repo gotchas, build commands, local conventions — fast-access notes for this repo |
+| **memo-cli** | Qdrant (shared remote) | Permanent, shared across all people and agents | Architectural decisions, integration contracts, structural choices, configuration rationale |
 
-### Decision Tree: Where to Store Information
+### Decision Tree: Where Does This Information Belong?
 
-1. **Is it an architectural decision, design rationale, or integration contract?** → `memo write`
-2. **Is it a repo-specific convention or gotcha that all agents should know?** → `/memories/repo/` AND consider `memo write` if it reflects an architectural choice
-3. **Is it a personal preference or general pattern?** → `/memories/` (user memory)
-4. **Is it temporary, in-progress context for this session only?** → `/memories/session/`
+```
+Is it a decision, rationale, constraint, contract, or config choice?
+  └─ YES → memo write  (it belongs to the shared knowledge base)
+
+Is it a repo-specific gotcha or quick operational fact?
+  └─ YES → /memories/repo/ (and also memo write if it reflects a real design choice)
+
+Is it a personal preference or general agent pattern?
+  └─ YES → /memories/ (user memory)
+
+Is it temporary context that only matters for the current session?
+  └─ YES → /memories/session/
+```
+
+**Key principle:** If the information would help a *different* developer or agent working in the same codebase — even a year from now — it belongs in `memo-cli`.
 
 ---
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: npm
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       contents: read
       id-token: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ Skills are in `.github/skills/` and are loaded only on demand.
 | Skill | Directory | Purpose | Primary Consumer |
 | --- | --- | --- | --- |
 | git-ops | `.github/skills/git-ops/` | Branch creation, sync/rebase workflow, merge/conflict handling, and recovery. | developer, planner |
+| memo-cli-usage | `.github/skills/memo-cli-usage/` | Agent guidance for memo-cli operations: command reference, workflows, memory scopes, and safe-operation guardrails. | Any agent |
 | webapp-mockup | `.github/skills/webapp-mockup/` | Build mockups for UX validation loops. | ux-engineer |
 
 ---

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Agent-first CLI for capturing and querying development decisions via a Qdrant vector store.
 
-`@llipe/memo-cli` lets AI agents and developers record architectural decisions, integration points, and structural choices during development — then retrieve them semantically at any time.
+`@llipe.com/memo-cli` lets AI agents and developers record architectural decisions, integration points, and structural choices during development — then retrieve them semantically at any time.
 
 ---
 
@@ -45,7 +45,7 @@
 ### From npm (recommended)
 
 ```bash
-npm install -g @llipe/memo-cli
+npm install -g @llipe.com/memo-cli
 memo --version
 ```
 
@@ -604,7 +604,7 @@ cp -r .github/skills/memo-cli-usage /path/to/your-repo/.github/skills/
 # | memo-cli-usage | .github/skills/memo-cli-usage/ | Agent guidance for memo-cli | Any agent |
 
 # 3. Install memo-cli
-pnpm add -D @llipe/memo-cli
+pnpm add -D @llipe.com/memo-cli
 
 # 4. Initialize the repo
 npx memo setup init --repo <name> --org <org> --domain <domain>
@@ -647,15 +647,17 @@ cp .env.example .env   # configure credentials
 
 ### Scripts
 
-| Script                   | Description                                  |
-| ------------------------ | -------------------------------------------- |
-| `pnpm run build`         | Compile TypeScript to `dist/`                |
-| `pnpm run typecheck`     | Type-check without emitting                  |
-| `pnpm run lint`          | ESLint (v9 flat config, strict type-checked) |
-| `pnpm run lint:fix`      | ESLint with auto-fix                         |
-| `pnpm run format`        | Prettier format                              |
-| `pnpm run test`          | Run Jest test suite                          |
-| `pnpm run test:coverage` | Run Jest with coverage report                |
+| Script                     | Description                                  |
+| -------------------------- | -------------------------------------------- |
+| `pnpm run build`           | Compile TypeScript to `dist/`                |
+| `pnpm run build:watch`     | Compile in watch mode                        |
+| `pnpm run typecheck`       | Type-check without emitting                  |
+| `pnpm run lint`            | ESLint (v9 flat config, strict type-checked) |
+| `pnpm run lint:fix`        | ESLint with auto-fix                         |
+| `pnpm run format`          | Prettier format                              |
+| `pnpm run format:check`    | Check formatting without writing             |
+| `pnpm run test`            | Run Jest test suite                          |
+| `pnpm run test:coverage`   | Run Jest with coverage report                |
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > Agent-first CLI for capturing and querying development decisions via a Qdrant vector store.
 
+GitHub: [https://github.com/llipe/memo-cli](https://github.com/llipe/memo-cli)
+
 `@llipe.com/memo-cli` lets AI agents and developers record architectural decisions, integration points, and structural choices during development — then retrieve them semantically at any time.
 
 ---

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
   - [Step 8: Delete Entries](#step-8-delete-entries)
 - [Command Reference](#command-reference)
 - [Agent Integration](#agent-integration)
+  - [Agent Skill (memo-cli-usage)](#agent-skill-memo-cli-usage)
 - [Bootstrap Workflow](#bootstrap-workflow)
 - [Development](#development)
 - [Project Structure](#project-structure)
@@ -570,6 +571,46 @@ export EMBEDDINGS_API_KEY=sk-...
 ```
 
 No `.env` file needed — agents should inject variables directly into the process environment.
+
+### Agent Skill (memo-cli-usage)
+
+This repository ships a reusable agent skill at [`.github/skills/memo-cli-usage/SKILL.md`](.github/skills/memo-cli-usage/SKILL.md) that teaches AI agents (and developers) how to operate memo-cli correctly and consistently.
+
+The skill is **self-contained and installable** — copy the `memo-cli-usage/` folder into any repository's `.github/skills/` directory and reference it from that repo's agent registry.
+
+#### What the skill covers
+
+| Section | Description |
+|---------|-------------|
+| **When to write / when to search** | Precise trigger tables — which moment calls for a `memo write`, which calls for a `memo search` first |
+| **`repo`, `org`, `domain` explained** | What each identity field means, how to choose values, and why they matter for scoping |
+| **`relates_to` explained** | When to add a repo, how cross-repo queries work, and how to avoid over-populating the list |
+| **Tag strategy** | Five-layer taxonomy (domain, technology, entry nature, story ref, scope), naming rules, and ready-made examples |
+| **Writing quality** | The context + decision + rationale formula with side-by-side good/bad examples |
+| **Intent & outcome entries** | How to narrate agent work as it happens — write before starting, write after finishing |
+| **Recording file changes** | How to annotate which files changed and explain why those were the right files |
+| **Recording config decisions** | Env vars, storage layout, feature flags, schema versions — what to capture and why |
+| **Multi-developer & cross-session** | Shared KB, session continuity for stateless agents, multi-day work pattern |
+| **Memory scope decision tree** | When to use IDE/agent memory (`/memories/`) vs. memo-cli |
+| **Safe operation guardrails** | Non-destructive defaults, `--json` mode rules, error handling, credential safety |
+
+#### Install into another repository
+
+```bash
+# 1. Copy the skill
+cp -r .github/skills/memo-cli-usage /path/to/your-repo/.github/skills/
+
+# 2. Register it in your AGENTS.md or skill registry:
+# | memo-cli-usage | .github/skills/memo-cli-usage/ | Agent guidance for memo-cli | Any agent |
+
+# 3. Install memo-cli
+pnpm add -D @llipe/memo-cli
+
+# 4. Initialize the repo
+npx memo setup init --repo <name> --org <org> --domain <domain>
+```
+
+Once the skill is registered, any agent (GitHub Copilot, Claude, GPT-4, etc.) that loads it will know how to record decisions, restore session context, tag consistently, and stay safe.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@llipe.com/memo-cli",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Agent-first CLI for capturing and querying development decisions via Qdrant vector store",
   "type": "module",
   "author": "llipe",

--- a/workstream/github-publication-prd-001-mvp.md
+++ b/workstream/github-publication-prd-001-mvp.md
@@ -19,6 +19,7 @@
 | S-007    | Bootstrap Prompt Documentation & Validation Workflow             | https://github.com/llipe/memo-cli/issues/7  | story, mvp          | MVP — PRD-001 Core Loop |
 | S-008    | First Release — Package Build, Publish, and Install Verification | https://github.com/llipe/memo-cli/issues/8  | story, mvp, release | MVP — PRD-001 Core Loop |
 | S-009    | Automated Registry Deployment Workflow (npm)                     | https://github.com/llipe/memo-cli/issues/21 | story, mvp, release | MVP — PRD-001 Core Loop |
+| S-010    | `memo get` — Read a Specific Entry by ID                         | https://github.com/llipe/memo-cli/issues/32 | story, mvp          | MVP — PRD-001 Core Loop |
 
 ## Labels Created
 
@@ -47,6 +48,7 @@ S-001 (no deps)
 
 - Initial publication (S-001 to S-008) completed on 2026-04-10 under milestone **MVP — PRD-001 Core Loop** (#1)
 - Sync update on 2026-04-17 created S-009: https://github.com/llipe/memo-cli/issues/21
+- Sync update on 2026-04-18 created S-010: https://github.com/llipe/memo-cli/issues/32
 - No stories skipped — full PRD-001 coverage (see coverage report in `user-stories-prd-001-mvp.md`)
 - GitHub is now the source of truth for execution tracking
 - Suggested next step: run the **plan** activity to create task lists from selected stories

--- a/workstream/issue-33-global-credential-config-refinement.md
+++ b/workstream/issue-33-global-credential-config-refinement.md
@@ -1,0 +1,132 @@
+# Issue Refinement: #33 — Global Credential Configuration with Local Directory Overrides
+
+## Changelog
+
+| Version | Date       | Summary                  | Author              |
+|---------|------------|--------------------------|---------------------|
+| 1.0     | 2026-04-18 | Initial refinement       | product-engineer    |
+
+---
+
+## Summary
+
+- **Goal:** Replace the single-source `.env` credential model with a layered, AWS-CLI-style resolution that lets a globally installed `memo` binary share credentials across all repositories on the same machine, while allowing per-directory overrides.
+- **Primary user impact:** Developers with `memo` installed globally no longer need a `.env` file in each repository. Credentials are set once via `memo setup credentials` and reused everywhere.
+- **Non-goals:**
+  - Remote/distributed config registry (Phase 2).
+  - Multi-profile / named-profile support (may follow in a later story).
+  - Changes to the `memo.config.json` repo identity schema.
+  - Credential rotation or vault integration.
+
+---
+
+## Problem Being Solved
+
+Currently, `memo-cli` reads `QDRANT_URL`, `QDRANT_API_KEY`, `EMBEDDINGS_PROVIDER`, and `EMBEDDINGS_API_KEY` exclusively from environment variables, typically via a `.env` file populated manually in each project. This forces every repository to carry its own `.env` even when the Qdrant instance and embeddings provider are shared across all projects on the same machine. For a globally installed tool, this is a significant friction point.
+
+---
+
+## Design: Layered Credential Resolution
+
+Credentials are resolved in priority order (highest first):
+
+| Priority | Source | Location | Notes |
+|----------|--------|----------|-------|
+| 1 | Environment variables | `process.env` | Existing behavior; always wins |
+| 2 | Local directory file | `.memo.local` in CWD | Per-project override; **must be gitignored** |
+| 3 | Global user config | `~/.config/memo/config.json` | Machine-wide default; written by `memo setup credentials` |
+
+Partial merges are supported: a field present in a lower-priority source fills in gaps not covered by higher-priority sources.
+
+### Global Config Format (`~/.config/memo/config.json`)
+
+```json
+{
+  "qdrant_url": "https://...",
+  "qdrant_api_key": "eyJ...",
+  "embeddings_provider": "openai",
+  "embeddings_api_key": "sk-..."
+}
+```
+
+### Local Override Format (`.memo.local` in CWD)
+
+Same JSON schema as global config. Only fields present in the file are applied; absent fields fall through to global config or env vars.
+
+### File Permissions
+
+On POSIX systems, both files are written with mode `0600` (owner read/write only). Windows is not affected.
+
+---
+
+## Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Config format | JSON (same as `memo.config.json`) | Consistent with existing tooling; easy to read/write with existing Zod/Node.js stack |
+| Global config path | `~/.config/memo/config.json` | Follows XDG Base Directory spec; widely used by modern CLI tools |
+| Local override filename | `.memo.local` | Clear memo namespace; `.local` suffix signals machine-local content not for VCS |
+| **Not** INI format | JSON chosen over INI | INI would require a new parser dependency; JSON matches the existing stack |
+| No named profiles (v1) | Single credential set per scope | Keeps complexity low; profiles can follow as a later story |
+| `.gitignore` auto-injection | Yes, for `--local` | Prevents accidental credential commits |
+
+---
+
+## Acceptance Criteria
+
+- [ ] `memo setup credentials` prompts interactively for all four credential fields and writes to `~/.config/memo/config.json`.
+- [ ] `memo setup credentials --local` writes to `.memo.local` in CWD and injects `.memo.local` into `.gitignore` if not already present.
+- [ ] All commands resolve credentials in layered priority order; partial overrides are supported.
+- [ ] `memo setup show` displays resolved credential config with per-field source annotations (`env` / `local` / `global`).
+- [ ] `memo setup show --json` outputs source map without echoing secret values (`{ "field": { "source": "...", "present": true } }`).
+- [ ] Missing `QDRANT_URL` from all sources → `MISSING_CREDENTIAL` error with hint pointing to `memo setup credentials`.
+- [ ] Global config directory is created automatically on first write.
+- [ ] `0600` permissions applied on POSIX after write.
+- [ ] `memo.config.json` (repo identity) is fully unaffected.
+
+---
+
+## Constraints
+
+- **Security:** Secret field values must never be printed to stdout or logged, in any output mode.
+- **Backward compatibility:** Existing `.env` / env-var-only workflows must continue to work without change (env vars remain priority 1).
+- **No new runtime dependencies:** Use Node.js built-ins (`os.homedir()`, `fs.chmod()`) and existing `zod`/`dotenv` stack.
+- **Windows:** `0600` chmod is skipped on Windows (`process.platform !== 'win32'`); document this limitation.
+
+---
+
+## Risks and Edge Cases
+
+| Risk / Edge Case | Mitigation |
+|------------------|------------|
+| `.memo.local` accidentally committed | Auto-inject into `.gitignore` on `--local` write |
+| Global config file not yet created; command expects credentials | Clear `MISSING_CREDENTIAL` error with actionable hint |
+| Multiple `QDRANT_URL` sources (env + global) | Env always wins; log source in `show` for debugging |
+| Partial `.memo.local` (only some fields set) | Layer merge fills remaining fields from global config |
+| XDG `$HOME` not writable | Propagate `NODE:EACCES` as `MemoError('CONFIG_WRITE_FAILED', ...)` |
+| Existing `process.env` reads in commands | All six existing commands + future `get` (#32) must be updated |
+
+---
+
+## Dependencies
+
+- S-002 (Issue #2) — `memo setup` base implementation (delivered ✅)
+- Issue #32 — `memo get` — coordinate migration to `loadCredentialConfig` across all commands
+
+---
+
+## Testing Notes
+
+- **Unit tests:** `loadCredentialConfig` — all three layers independently, partial merge, env override, missing credential, `getGlobalConfigPath` helper.
+- **Unit tests:** `memo setup credentials` wizard — global write path (mocked `fs`), `--local` path, `.gitignore` injection (file exists vs not exists).
+- **Unit tests:** `memo setup show` — source annotation rendering, JSON output structure.
+- **Integration tests:** Not required for this story (credential resolution is tested via unit tests with mock FS).
+- **Manual check:** Run `memo search "..."` with only `~/.config/memo/config.json` set, no `.env` in CWD — verify it works.
+- **Manual check:** Add `.memo.local` with a different `QDRANT_URL`, verify local override is used.
+
+---
+
+## Open Questions
+
+- Should `EMBEDDINGS_PROVIDER` default to `openai` at the resolution layer (applied when no source provides a value), or should it remain a hard-coded default in `EmbeddingsFactory`? **Proposed:** Keep default in `EmbeddingsFactory`; `loadCredentialConfig` returns `undefined` for unset optional fields and callers apply defaults.
+- Named profiles (e.g., `memo setup credentials --profile staging`)? **Deferred** to a follow-up story.

--- a/workstream/tasks-issue-26-memo-cli-usage-skill.md
+++ b/workstream/tasks-issue-26-memo-cli-usage-skill.md
@@ -1,0 +1,24 @@
+# Implementation Plan - Issue #26: Create memo-cli Usage Skill
+
+## Relevant Files
+
+- `.github/skills/memo-cli-usage/SKILL.md` - Main skill definition
+- `AGENTS.md` - Agent/skill registry (update skill table)
+
+## Tasks
+
+- [ ] 1.0 Implement Issue #26 - https://github.com/llipe/memo-cli/issues/26: Create memo-cli usage skill for agents
+  - [ ] 1.1 Create `.github/skills/memo-cli-usage/SKILL.md` with full skill definition
+    - Skill purpose, scope, and when-to-use guidance
+    - Complete command reference (setup, write, search, list, tags, inspect, delete)
+    - Memory scope guidance (`/memories`, `/memories/session`, `/memories/repo`)
+    - Safe operation guardrails (non-destructive defaults, validation, error handling)
+    - Multi-developer / cross-session context sharing best practices
+    - Installable design (self-contained, copy & paste into another repo)
+  - [ ] 1.2 Update `AGENTS.md` to register the new skill in the Skills table
+  - [ ] 1.3 Verify Acceptance Criterion: Skill definition exists with clear purpose, scope, and usage instructions
+  - [ ] 1.4 Verify Acceptance Criterion: Skill documents common command examples for all flows
+  - [ ] 1.5 Verify Acceptance Criterion: Skill includes guardrails for safe operations
+  - [ ] 1.6 Verify Acceptance Criterion: Skill explains memory scopes
+  - [ ] 1.7 Verify Acceptance Criterion: Skill is referenced in AGENTS.md
+  - [ ] 1.8 Verify Acceptance Criterion: Skill instructions are actionable in this repository

--- a/workstream/tasks-issue-26-memo-cli-usage-skill.md
+++ b/workstream/tasks-issue-26-memo-cli-usage-skill.md
@@ -7,18 +7,18 @@
 
 ## Tasks
 
-- [ ] 1.0 Implement Issue #26 - https://github.com/llipe/memo-cli/issues/26: Create memo-cli usage skill for agents
-  - [ ] 1.1 Create `.github/skills/memo-cli-usage/SKILL.md` with full skill definition
+- [x] 1.0 Implement Issue #26 - https://github.com/llipe/memo-cli/issues/26: Create memo-cli usage skill for agents
+  - [x] 1.1 Create `.github/skills/memo-cli-usage/SKILL.md` with full skill definition
     - Skill purpose, scope, and when-to-use guidance
     - Complete command reference (setup, write, search, list, tags, inspect, delete)
     - Memory scope guidance (`/memories`, `/memories/session`, `/memories/repo`)
     - Safe operation guardrails (non-destructive defaults, validation, error handling)
     - Multi-developer / cross-session context sharing best practices
     - Installable design (self-contained, copy & paste into another repo)
-  - [ ] 1.2 Update `AGENTS.md` to register the new skill in the Skills table
-  - [ ] 1.3 Verify Acceptance Criterion: Skill definition exists with clear purpose, scope, and usage instructions
-  - [ ] 1.4 Verify Acceptance Criterion: Skill documents common command examples for all flows
-  - [ ] 1.5 Verify Acceptance Criterion: Skill includes guardrails for safe operations
-  - [ ] 1.6 Verify Acceptance Criterion: Skill explains memory scopes
-  - [ ] 1.7 Verify Acceptance Criterion: Skill is referenced in AGENTS.md
-  - [ ] 1.8 Verify Acceptance Criterion: Skill instructions are actionable in this repository
+  - [x] 1.2 Update `AGENTS.md` to register the new skill in the Skills table
+  - [x] 1.3 Verify Acceptance Criterion: Skill definition exists with clear purpose, scope, and usage instructions
+  - [x] 1.4 Verify Acceptance Criterion: Skill documents common command examples for all flows
+  - [x] 1.5 Verify Acceptance Criterion: Skill includes guardrails for safe operations
+  - [x] 1.6 Verify Acceptance Criterion: Skill explains memory scopes
+  - [x] 1.7 Verify Acceptance Criterion: Skill is referenced in AGENTS.md
+  - [x] 1.8 Verify Acceptance Criterion: Skill instructions are actionable in this repository

--- a/workstream/tasks-ranking-retrieval-plan.md
+++ b/workstream/tasks-ranking-retrieval-plan.md
@@ -1,0 +1,82 @@
+# Implementation Plan — Ranking & Retrieval Improvement
+
+## Relevant Files
+
+- `src/types/config.ts` — Add `RankingConfig`, `AskConfig` Zod schemas; extend `MemoConfig`
+- `src/lib/ranking.ts` — **New** — composite scoring, confidence tiers, tag boost
+- `src/lib/staleness.ts` — **New** — Jaccard overlap, staleness detection
+- `src/lib/llm.ts` — **New** — LLM client adapter (`buildAskPrompt`, `parseAskResponse`)
+- `src/lib/config.ts` — Load/validate `ranking` and `ask` blocks with defaults
+- `src/lib/qdrant.ts` — Over-fetch, expose raw similarity, add `fetchByRepo`
+- `src/lib/output.ts` — Human output: confidence tier prefix, stale warning
+- `src/commands/search.ts` — Apply ranking, tiers, tag boost, staleness detection
+- `src/commands/setup.ts` — Extend `validate` to check weights sum + threshold ordering
+- `src/commands/ask.ts` — **New** — full `memo ask` command
+- `src/adapters/openai-llm.ts` — **New** — OpenAI chat completion adapter
+- `src/index.ts` — Register `ask` command
+- `tests/unit/lib/ranking.test.ts` — **New** — ranking unit tests
+- `tests/unit/lib/staleness.test.ts` — **New** — staleness unit tests
+- `tests/unit/lib/llm.test.ts` — **New** — LLM unit tests
+- `tests/unit/commands/ask.test.ts` — **New** — ask command unit tests
+
+## Tasks
+
+- [ ] 1.0 Implement Issue #34: Composite Ranking Score ([https://github.com/llipe/memo-cli/issues/34](https://github.com/llipe/memo-cli/issues/34))
+  - [ ] 1.1 Add `RankingConfig` Zod schema and extend `MemoConfig` in `src/types/config.ts`
+  - [ ] 1.2 Create `src/lib/ranking.ts` with `computeRecencyScore`, `computeSourceScore`, `computeCompositeScore`, `rankResults`
+  - [ ] 1.3 Update `src/lib/qdrant.ts` to over-fetch `limit * 3` (capped at 50) and expose raw similarity + metadata
+  - [ ] 1.4 Load and validate `ranking` block with defaults in `src/lib/config.ts`
+  - [ ] 1.5 Extend `memo setup validate` in `src/commands/setup.ts` to check weights sum to 1.0
+  - [ ] 1.6 Update `src/commands/search.ts` to call `rankResults` after fetch and slice to `--limit`
+  - [ ] 1.7 Write unit tests in `tests/unit/lib/ranking.test.ts`
+  - [ ] 1.8 Verify AC: composite ordering, JSON output shape (`final_score`, `similarity`, `recency_score`, `source_score`), config validation
+  - [ ] 1.9 Run tests: `pnpm test -- --testPathPattern="ranking|search|setup"`
+
+- [ ] 2.0 Implement Issue #36: Tag Overlap Boosting ([https://github.com/llipe/memo-cli/issues/36](https://github.com/llipe/memo-cli/issues/36))
+  > Can be done in parallel with Task 1.0 — independent story.
+  - [ ] 2.1 Add `tag_boost_factor` to `RankingConfig` in `src/types/config.ts`
+  - [ ] 2.2 Add `computeTagBoost(query, entryTags, boostFactor)` to `src/lib/ranking.ts` (or create standalone if 1.0 not yet merged)
+  - [ ] 2.3 Apply `computeTagBoost` in `rankResults`, cap at 1.0, attach `tag_boost` to result
+  - [ ] 2.4 Update `src/commands/search.ts` to pass raw query string into `rankResults`
+  - [ ] 2.5 Write/extend unit tests in `tests/unit/lib/ranking.test.ts`
+  - [ ] 2.6 Verify AC: boost applied, case-insensitive whole-word matching, stopword exclusion, `tag_boost: 0` when factor is 0
+  - [ ] 2.7 Run tests: `pnpm test -- --testPathPattern="ranking|search"`
+
+- [ ] 3.0 Implement Issue #35: Dynamic Confidence Tiers ([https://github.com/llipe/memo-cli/issues/35](https://github.com/llipe/memo-cli/issues/35))
+  > Requires Task 1.0 to be completed first.
+  - [ ] 3.1 Add `confidence_thresholds` to `RankingConfig` in `src/types/config.ts`
+  - [ ] 3.2 Add `computeConfidenceTier(finalScore, thresholds)` to `src/lib/ranking.ts`
+  - [ ] 3.3 Extend `memo setup validate` to reject invalid threshold ordering (e.g., `exact` < `high`)
+  - [ ] 3.4 Attach `confidence_tier` to each result in `src/commands/search.ts`
+  - [ ] 3.5 Update `src/lib/output.ts` human output to display tier label prefix `[exact]`, `[high]`, etc.
+  - [ ] 3.6 Remove static `confidence: "high"` field from output
+  - [ ] 3.7 Write/extend unit tests in `tests/unit/lib/ranking.test.ts`
+  - [ ] 3.8 Update existing search tests to expect `confidence_tier` instead of `confidence`
+  - [ ] 3.9 Verify AC: correct tier per score range, custom thresholds, human output format
+  - [ ] 3.10 Run tests: `pnpm test -- --testPathPattern="ranking|search"`
+
+- [ ] 4.0 Implement Issue #38: Staleness Detection ([https://github.com/llipe/memo-cli/issues/38](https://github.com/llipe/memo-cli/issues/38))
+  > Requires Task 1.0 to be completed first.
+  - [ ] 4.1 Add staleness fields (`staleness_threshold_days`, `staleness_tag_overlap_threshold`) to `RankingConfig` in `src/types/config.ts`
+  - [ ] 4.2 Create `src/lib/staleness.ts` with `computeJaccardOverlap` and `detectStaleness`
+  - [ ] 4.3 Add `fetchByRepo(repo): EntryPayload[]` to `QdrantRepository` using Qdrant scroll
+  - [ ] 4.4 Update `src/commands/search.ts` to call `fetchByRepo` once, then run `detectStaleness` per result
+  - [ ] 4.5 Attach `stale` and `superseded_by` to result; omit `stale` key entirely when false in JSON output
+  - [ ] 4.6 Update human output to show `⚠ STALE — superseded by <id>` inline when `stale: true`
+  - [ ] 4.7 Write unit tests in `tests/unit/lib/staleness.test.ts`
+  - [ ] 4.8 Verify AC: stale flagging, omit-when-false, one scroll per invocation, no effect on `final_score`
+  - [ ] 4.9 Run tests: `pnpm test -- --testPathPattern="staleness|search"`
+
+- [ ] 5.0 Implement Issue #37: `memo ask` Command ([https://github.com/llipe/memo-cli/issues/37](https://github.com/llipe/memo-cli/issues/37))
+  > Requires Tasks 1.0 and 3.0 to be completed first.
+  - [ ] 5.1 Add `AskConfig` Zod schema and extend `MemoConfig` in `src/types/config.ts`
+  - [ ] 5.2 Create `src/adapters/openai-llm.ts` — OpenAI chat completion adapter
+  - [ ] 5.3 Create `src/lib/llm.ts` with `buildAskPrompt`, `parseAskResponse`, and LLM client dispatcher
+  - [ ] 5.4 Create `src/commands/ask.ts` — full `memo ask` command with `--scope`, `--limit`, `--json` flags
+  - [ ] 5.5 Register `memo ask` in `src/index.ts`
+  - [ ] 5.6 Implement low-confidence filter (exclude `confidence_tier: low` before LLM call)
+  - [ ] 5.7 Implement exit code 1 for missing `memo.config.json`, exit code 2 for unreachable LLM API
+  - [ ] 5.8 Write unit tests in `tests/unit/commands/ask.test.ts`
+  - [ ] 5.9 Write unit tests in `tests/unit/lib/llm.test.ts`
+  - [ ] 5.10 Verify AC: grounded/ungrounded answers, low-confidence filtering, JSON output shape, `grounded` field
+  - [ ] 5.11 Run tests: `pnpm test -- --testPathPattern="ask|llm"`

--- a/workstream/user-stories-prd-001-mvp.md
+++ b/workstream/user-stories-prd-001-mvp.md
@@ -6,6 +6,7 @@
 | ------- | ---------- | ----------------------------------------- | -------------- |
 | 1.0     | 2026-04-10 | Initial version                           | GitHub Copilot |
 | 1.1     | 2026-04-17 | Added S-009 npm deployment workflow story | GitHub Copilot |
+| 1.2     | 2026-04-18 | Added S-010 `memo get` read entry by id   | GitHub Copilot |
 
 ---
 
@@ -777,14 +778,93 @@ This story formalizes release automation beyond manual first-release steps. It a
 
 ---
 
+### Story S-010: `memo get` — Read a Specific Entry by ID
+
+**Priority:** Medium
+**Estimated Size:** S
+**Dependencies:** S-003
+
+#### User Story
+
+As an AI agent or developer,
+I want to fetch the full content of a specific memo entry using its ID,
+So that I can inspect an individual decision in detail without having to run a search or list operation.
+
+#### Context
+
+`memo get` fills the read-by-identity gap in the CLI. Once a decision ID is known (e.g., from `memo search --json`, `memo list --json`, or a stored reference), an agent or developer must be able to retrieve the complete payload without any ambiguity. The command uses the Qdrant point ID, which is a UUID stored on every written entry. This command is intentionally read-only and requires no embeddings or config file.
+
+#### Acceptance Criteria
+
+- [ ] `memo get <id>` fetches the entry with the given UUID from Qdrant and prints all payload fields in human-readable form.
+- [ ] `memo get <id> --json` returns the full payload as a JSON object to stdout.
+- [ ] When no entry exists for the given ID, the command exits with code `1` and error code `ENTRY_NOT_FOUND`.
+- [ ] `memo get` does not require a local `memo.config.json` — it only needs `QDRANT_URL` (and optionally `QDRANT_API_KEY`).
+- [ ] Human output renders key fields with chalk colors: `cyan` for labels, `bold` for rationale, `gray` for metadata (timestamp, source, confidence, commit, story).
+- [ ] `--json` output is a flat JSON object matching the full stored payload schema; no extra wrapper.
+- [ ] The command auto-bootstraps the collection if it does not exist (consistent with other read commands).
+
+#### Business Rules
+
+- The ID argument is always a UUID string (the Qdrant point ID of the entry).
+- Unlike `memo search` or `memo list`, no repo/org/domain context is needed — the ID is globally unique within the collection.
+- The command is read-only: it MUST NOT modify any data.
+
+#### Technical Notes
+
+- Add `getById(id: string): Promise<ScrollResult | null>` method to `QdrantRepository` using `scroll` with `has_id` filter (same pattern as `buildHasIdFilter` in `delete.ts`).
+- Command is registered as `memo get <id>` (positional argument).
+- Human output fields (in display order): `id`, `repo`, `org`, `domain`, `entry_type`, `source`, `confidence`, `tags`, `rationale`, `commit`, `story`, `files_modified`, `relates_to`, `timestamp_utc`.
+- Fields that are absent or empty arrays/strings are omitted from human output but preserved in JSON output.
+- No spinner needed — the lookup is fast and uses a single Qdrant call.
+- Error handling: propagate `MemoError('ENTRY_NOT_FOUND', ...)` on null result.
+
+#### Testing Requirements
+
+- **Unit Tests:** `handleGet` with mock repo returning an entry; `handleGet` with repo returning `null` → `ENTRY_NOT_FOUND`; human output field ordering and chalk rendering; JSON output matches payload exactly.
+- **Integration Tests:** `memo get <id> --json` contract when entry exists; `ENTRY_NOT_FOUND` on missing ID.
+- **Manual Testing:** Write a test entry, capture its ID from `--json` output, run `memo get <id>` and verify all fields display correctly; run `memo get nonexistent-id` and verify error.
+- **Edge Cases:** ID that is valid UUID format but not in collection; `QDRANT_URL` not set (→ `MISSING_CREDENTIAL`).
+
+#### Implementation Steps
+
+1. Add `getById(id: string): Promise<ScrollResult | null>` to `QdrantRepository` in `src/lib/qdrant.ts`.
+2. Create `src/commands/get.ts`: define `GetFlags`, `GetDeps`, and `handleGet()` function.
+3. Implement human output renderer for a single entry (fields, chalk labels, omit empty fields).
+4. Implement `--json` path returning the raw payload object.
+5. Register `memo get <id>` in `src/index.ts`.
+6. Write unit tests in `tests/unit/commands/get.test.ts`.
+7. Extend `tests/unit/lib/qdrant.test.ts` with `getById` coverage.
+8. Write integration tests in `tests/integration/commands/get.test.ts`.
+9. Verify AC: entry found (human mode), entry found (JSON mode), entry not found (error code).
+
+#### Files to Create/Modify
+
+- `src/lib/qdrant.ts` — add `getById()` method
+- `src/commands/get.ts` — new command implementation
+- `src/index.ts` — register `memo get` command
+- `tests/unit/commands/get.test.ts` — unit tests
+- `tests/unit/lib/qdrant.test.ts` — extend with `getById` tests
+- `tests/integration/commands/get.test.ts` — integration tests
+
+#### Definition of Done Checklist
+
+- [ ] Code implemented per technical guidelines
+- [ ] Unit tests written and passing
+- [ ] Code reviewed and approved
+- [ ] Acceptance criteria verified
+- [ ] Pull Request created and merged
+
+---
+
 ## Coverage Validation
 
 ### Summary
 
 - **Total PRD Requirements:** 25 functional requirements + 12 acceptance criteria + 5 business rules
-- **Total User Stories:** 9
+- **Total User Stories:** 10
 - **Coverage:** 100%
-- **Status:** Complete
+- **Status:** Complete (S-010 extends read capabilities beyond MVP scope)
 
 ### Requirement Mapping
 

--- a/workstream/user-stories-ranking-retrieval.md
+++ b/workstream/user-stories-ranking-retrieval.md
@@ -1,0 +1,106 @@
+# User Stories — Ranking & Retrieval Improvement
+
+## GitHub Issues
+
+| Story | Issue | Title |
+|-------|-------|-------|
+| Story 1 | [#34](https://github.com/llipe/memo-cli/issues/34) | feat: composite ranking score for search results |
+| Story 2 | [#35](https://github.com/llipe/memo-cli/issues/35) | feat: dynamic confidence tiers in search output |
+| Story 3 | [#36](https://github.com/llipe/memo-cli/issues/36) | feat: tag overlap boosting in search results |
+| Story 4 | [#38](https://github.com/llipe/memo-cli/issues/38) | feat: staleness detection flag on search results |
+| Story 5 | [#37](https://github.com/llipe/memo-cli/issues/37) | feat: memo ask command with LLM re-ranking |
+
+## Dependency Map
+
+```
+Story 1 — Composite Ranking Score (#34)
+    └── Story 2 — Confidence Tiers (#35)
+    └── Story 4 — Staleness Detection (#38)
+    └── Story 5 — ask command (#37)
+              └── Story 2 — Confidence Tiers (#35) [also required]
+
+Story 3 — Tag Overlap Boosting (#36)   ← independent
+```
+
+## Recommended Implementation Order
+
+| # | Story | Issue | Depends On | Complexity |
+|---|-------|-------|------------|------------|
+| 1 | Composite Ranking Score | #34 | — | Medium |
+| 2 | Tag Overlap Boosting | #36 | — | Low |
+| 3 | Confidence Tiers | #35 | #34 | Low |
+| 4 | Staleness Detection | #38 | #34 | Medium |
+| 5 | `ask` Command | #37 | #34, #35 | High |
+
+Stories 1 (#34) and 3 (#36) can be worked in parallel. Stories 2 (#35) and 4 (#38) unlock after Story 1 ships.
+
+---
+
+## Story 1 — Composite Ranking Score (#34)
+
+As an AI agent consuming `memo search`, I want results ordered by a composite score that weights semantic similarity, entry recency, and source reliability — so that the most actionable and trustworthy decisions surface at the top, not just the most semantically similar ones.
+
+### Files to Create/Modify
+
+- `src/types/config.ts` — Add `RankingConfig` Zod schema; extend `MemoConfig`
+- `src/lib/ranking.ts` — **New** — `computeRecencyScore`, `computeSourceScore`, `computeCompositeScore`, `rankResults`
+- `src/lib/qdrant.ts` — Over-fetch `limit * 3` candidates (capped at 50)
+- `src/lib/config.ts` — Load and validate `ranking` block; apply defaults
+- `src/commands/search.ts` — Apply `rankResults` after fetch; slice to `--limit`
+- `src/commands/setup.ts` — Extend `validate` to check weights sum
+- `tests/unit/lib/ranking.test.ts` — **New** — unit tests
+
+---
+
+## Story 2 — Dynamic Confidence Tiers (#35)
+
+As an AI agent consuming `memo search`, I want each result to include a semantic confidence tier (`exact`, `high`, `medium`, `low`) derived from `final_score` — so I can programmatically decide whether to act on a result, surface it for review, or discard it.
+
+### Files to Create/Modify
+
+- `src/types/config.ts` — Add `confidence_thresholds` to `RankingConfig`
+- `src/lib/ranking.ts` — Add `computeConfidenceTier`
+- `src/commands/search.ts` — Attach `confidence_tier` to each result
+- `src/lib/output.ts` — Display tier label in human output
+
+---
+
+## Story 3 — Tag Overlap Boosting (#36)
+
+As an AI agent consuming `memo search`, I want results whose tags overlap with terms present in my query to receive a score boost — so that entries tagged with directly relevant concepts rank higher than semantically similar but differently-categorized ones.
+
+### Files to Create/Modify
+
+- `src/lib/ranking.ts` — Add `computeTagBoost`; apply in `rankResults`
+- `src/types/config.ts` — Add `tag_boost_factor` to `RankingConfig`
+- `src/commands/search.ts` — Pass raw query string into `rankResults`
+
+---
+
+## Story 4 — Staleness Detection (#38)
+
+As an AI agent consuming `memo search`, I want each result to include a `stale` flag when the entry is old and a newer entry with overlapping tags exists in the same repo — so I don't act on superseded decisions without awareness.
+
+### Files to Create/Modify
+
+- `src/lib/staleness.ts` — **New** — `computeJaccardOverlap`, `detectStaleness`
+- `src/lib/qdrant.ts` — Add `fetchByRepo(repo)` via Qdrant scroll
+- `src/commands/search.ts` — Run staleness detection after ranking
+- `src/types/config.ts` — Add staleness fields to `RankingConfig`
+- `tests/unit/lib/staleness.test.ts` — **New** — unit tests
+
+---
+
+## Story 5 — `memo ask` Command (#37)
+
+As an AI agent or developer, I want to run `memo ask "<question>"` and receive a direct, cited answer synthesized from the knowledge base — so I can get advisory responses grounded in stored decisions without manually interpreting raw search results.
+
+### Files to Create/Modify
+
+- `src/commands/ask.ts` — **New** — full command implementation
+- `src/lib/llm.ts` — **New** — LLM client adapter
+- `src/adapters/openai-llm.ts` — **New** — OpenAI chat completion adapter
+- `src/index.ts` — Register `ask` command
+- `src/types/config.ts` — Add `AskConfig` Zod schema
+- `tests/unit/commands/ask.test.ts` — **New** — unit tests
+- `tests/unit/lib/llm.test.ts` — **New** — unit tests


### PR DESCRIPTION
This pull request introduces several documentation updates, workflow improvements, and planning artifacts to support new features and better agent integration for the `memo-cli` project. The most notable changes include the introduction of a reusable agent skill for `memo-cli` usage, updates to the publishing workflow, and planning for upcoming features such as layered credential configuration and advanced ranking/retrieval logic.

**Agent skill integration and documentation:**

- Added a comprehensive, installable agent skill for `memo-cli` usage at `.github/skills/memo-cli-usage/SKILL.md`, with registration in `AGENTS.md` and detailed instructions in `README.md`. This skill guides agents and developers on when and how to use `memo-cli`, including command references, tagging strategies, memory scopes, and safety guardrails. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R70) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R577-R616) [[4]](diffhunk://#diff-a80a92ab1c239c04699ade275d17df74a206f4167fe7b1734f4bb54fa6dedecfR1-R24)
- Enhanced the `README.md` with explicit instructions for installing and integrating the agent skill, and updated examples to use the new scoped package name `@llipe.com/memo-cli`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R7) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-R50)

**Workflow and publishing improvements:**

- Updated the GitHub Actions publish workflow to force JavaScript actions to use Node.js 24 by setting the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable.
- Bumped the package version in `package.json` from `1.0.1` to `1.1.0` to reflect new features and improvements.

**Feature planning and roadmap:**

- Added a new user story (S-010) for the `memo get` command and recorded its addition in the MVP workstream documentation. [[1]](diffhunk://#diff-9ba85d41fa4b4955c15a9aa29c96864dc904471e69a264eedcc67fb4fb05c3b8R22) [[2]](diffhunk://#diff-9ba85d41fa4b4955c15a9aa29c96864dc904471e69a264eedcc67fb4fb05c3b8R51)
- Introduced a detailed refinement document for Issue #33, outlining a layered, AWS-CLI-style global credential configuration system with local directory overrides, including design, acceptance criteria, and testing notes.
- Added an implementation plan for advanced ranking and retrieval improvements, including composite scoring, tag boosting, confidence tiers, staleness detection, and the upcoming `memo ask` command.

**Developer experience:**

- Updated the scripts table in `README.md` to include new scripts for build watching and formatting checks.

These changes collectively improve agent usability, clarify project setup and integration, and lay the groundwork for upcoming features and architectural improvements.