### PR TITLE
Implement read-specific-id command for issue #32

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ GitHub: [https://github.com/llipe/memo-cli](https://github.com/llipe/memo-cli)
   - [Step 6: Discover Tags](#step-6-discover-tags)
   - [Step 7: Inspect the Knowledge Base](#step-7-inspect-the-knowledge-base)
   - [Step 8: Delete Entries](#step-8-delete-entries)
+  - [Step 9: Read a Single Entry](#step-9-read-a-single-entry)
 - [Command Reference](#command-reference)
 - [Agent Integration](#agent-integration)
   - [Agent Skill (memo-cli-usage)](#agent-skill-memo-cli-usage)
@@ -507,6 +508,33 @@ memo delete --id <id> --json
 
 ---
 
+### Step 9: Read a Single Entry
+
+Fetch one exact memo entry when you already know its ID.
+
+```bash
+memo read --id 550e8400-e29b-41d4-a716-446655440000
+```
+
+This command is read-only and does not require local `memo.config.json`.
+
+#### JSON mode
+
+```bash
+memo read --id 550e8400-e29b-41d4-a716-446655440000 --json
+```
+
+Returns the flat entry payload as JSON.
+
+#### All read flags
+
+| Flag     | Default | Description                 |
+| -------- | ------- | --------------------------- |
+| `--id`   | —       | Required entry id to fetch  |
+| `--json` | `false` | Output as JSON              |
+
+---
+
 ## Command Reference
 
 | Command               | Purpose                       | Key Flags                                                                       |
@@ -520,6 +548,7 @@ memo delete --id <id> --json
 | `memo tags list`      | Browse unique tags            | `--scope`, `--sort`, `--json`                                                   |
 | `memo inspect`        | Discover orgs/repos/domains   | `--orgs`, `--repos`, `--domains`, `--json`                                      |
 | `memo delete`         | Delete entries                | `--id`, `--all-by-repo`, `--all-by-org`, `--yes`, `--json`                      |
+| `memo read`           | Read one specific entry by id | `--id`, `--json`                                                                 |
 
 ### Global flags
 
@@ -690,7 +719,8 @@ src/
 │   ├── list.ts           # memo list (chronological + date range)
 │   ├── tags.ts           # memo tags list (unique tags with counts)
 │   ├── inspect.ts        # memo inspect (org/repo/domain facets)
-│   └── delete.ts         # memo delete (safe single + bulk delete)
+│   ├── delete.ts         # memo delete (safe single + bulk delete)
+│   └── read.ts           # memo read (single entry by ID)
 ├── lib/
 │   ├── qdrant.ts         # Qdrant collection management & queries
 │   ├── facets.ts         # Scroll-based facet aggregation

--- a/docs/adr/ADR-002-document-read-command-in-canonical-docs.md
+++ b/docs/adr/ADR-002-document-read-command-in-canonical-docs.md
@@ -1,0 +1,60 @@
+# ADR-002: Document `memo read --id` in Canonical Docs
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #32 introduced a new read-only command, `memo read --id <id>`, implemented in `src/commands/read.ts` and registered in `src/index.ts`.
+
+The command was already reflected in task/workstream artifacts and user-facing usage examples, but key canonical documentation inventories (system overview, technical architecture command trees, and current-state capability tables) were not fully aligned.
+
+This produced documentation drift where the codebase behavior included a command that was missing from some architecture and capability references.
+
+## Decision
+
+Update canonical documentation to explicitly include `memo read` wherever command inventories and current-state capability summaries are maintained:
+
+- Add `memo read` to command inventory and runtime flows in `docs/system-overview.md`.
+- Add `commands/read.ts` to architecture and repository structure sections in `docs/technical-guidelines.md`.
+- Add issue #32 (`memo read --id`) to delivered capabilities in `docs/product-context.md`.
+- Add `read.ts` to command tree in `README.md` for consistency with project structure.
+
+No behavior, CLI contract, tests, or implementation code changes were made.
+
+## Alternatives Considered
+
+1. Leave docs unchanged because README already had `memo read` usage.
+Rejected: canonical docs would remain internally inconsistent and not represent current behavior.
+
+2. Update only one canonical doc (for example, system overview).
+Rejected: partial updates preserve cross-document drift.
+
+3. Introduce a new standalone feature note file.
+Rejected: violates update-in-place principle and creates unnecessary documentation sprawl.
+
+## Consequences
+
+Positive:
+- Canonical docs now consistently represent implemented command surface.
+- Reduced ambiguity for contributors and agents relying on command inventories.
+- Maintains current-state documentation policy.
+
+Negative:
+- Requires ongoing discipline to keep command inventory sections synchronized as commands evolve.
+
+Follow-up:
+- Future command additions should include a documentation parity checklist across system overview, technical guidelines, product context, and README structure.
+
+## Related
+
+- Requirements: `docs/requirements/prd-001-mvp.md`
+- Workstream:
+  - `workstream/issue-32-read-specific-id-refinement.md`
+  - `workstream/tasks-issue-32-read-specific-id.md`
+- Docs updated:
+  - `docs/system-overview.md`
+  - `docs/technical-guidelines.md`
+  - `docs/product-context.md`
+  - `README.md`

--- a/docs/product-context.md
+++ b/docs/product-context.md
@@ -71,6 +71,7 @@ The MVP (Phase 1) has been fully implemented and merged. All eight original user
 | #18   | `memo tags list` — browse unique tags with sort and scope options | ✅ Complete |
 | #19   | `memo inspect` — discover orgs, repos, and domains in the store  | ✅ Complete |
 | #20   | `memo delete` — safe single and bulk delete with guardrails      | ✅ Complete |
+| #32   | `memo read --id` — read one specific entry by known ID           | ✅ Complete |
 
 The package is published as `@memo-ai/cli` on npm. CI/CD pipelines are green. The publish workflow triggers on semver tag push.
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -44,6 +44,7 @@ graph LR
 | `memo tags list`   | `tags.ts`    | Browse all unique tags stored in the collection with counts and sort options    |
 | `memo inspect`     | `inspect.ts` | Discover orgs, repos, and domains across the knowledge base with facet filters |
 | `memo delete`      | `delete.ts`  | Safely delete a single entry by ID or bulk-delete by repo/org                  |
+| `memo read`        | `read.ts`    | Read one exact entry by ID with human or JSON output                           |
 
 All commands support `--json` for machine-readable output. Human mode uses colored text via chalk.
 
@@ -149,6 +150,14 @@ Additional providers (Voyage, Cohere, Ollama) ship via the same `EmbeddingsAdapt
 3. **Single delete:** scroll to verify entry exists → show preview → prompt for confirmation (unless `--json` or `--yes`) → `deleteById(id)` → output result
 4. **Bulk delete:** scroll to count matching entries → prompt for confirmation (unless `--yes`) → `deleteByFilter(filter)` → output deleted count
 5. Empty-match bulk delete returns exit 0 with a no-entries-found message
+
+### Read Flow
+
+1. Validate `--id` and normalize non-empty value
+2. Auto-bootstrap Qdrant collection if needed
+3. Execute exact lookup by ID via `getById(id)`
+4. If no entry is found: return `ENTRY_NOT_FOUND` (exit code 1)
+5. If found: return full payload + `id` as flat object (`--json`) or ordered human-readable fields
 
 ---
 

--- a/docs/technical-guidelines.md
+++ b/docs/technical-guidelines.md
@@ -80,7 +80,8 @@ CLI Entry (src/index.ts)
         ├── commands/list.ts       → ListCommand (chronological + date range)
         ├── commands/tags.ts       → TagsCommand (list unique tags with counts)
         ├── commands/inspect.ts    → InspectCommand (org/repo/domain facets)
-        └── commands/delete.ts     → DeleteCommand (safe single + bulk delete)
+        ├── commands/delete.ts     → DeleteCommand (safe single + bulk delete)
+        └── commands/read.ts       → ReadCommand (single-entry lookup by ID)
 
 lib/
   ├── qdrant.ts            → QdrantRepository (collection mgmt, upsert, search, scroll, deleteById, deleteByFilter)
@@ -419,7 +420,11 @@ memo-cli/
 │   │   ├── setup.ts              ← memo setup (init / show / validate)
 │   │   ├── write.ts              ← memo write (with duplicate detection)
 │   │   ├── search.ts             ← memo search (semantic + pre-filters)
-│   │   └── list.ts               ← memo list (chronological + date range)
+│   │   ├── list.ts               ← memo list (chronological + date range)
+│   │   ├── tags.ts               ← memo tags list (unique tags with counts)
+│   │   ├── inspect.ts            ← memo inspect (org/repo/domain facets)
+│   │   ├── delete.ts             ← memo delete (safe single + bulk delete)
+│   │   └── read.ts               ← memo read (single entry by ID)
 │   ├── lib/
 │   │   ├── qdrant.ts             ← QdrantRepository
 │   │   ├── embeddings.ts         ← EmbeddingsAdapter interface + factory

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -1,0 +1,107 @@
+import { Command } from 'commander';
+import { MemoError } from '../lib/errors.js';
+import { output } from '../lib/output.js';
+import { QdrantRepository } from '../lib/qdrant.js';
+
+export interface ReadFlags {
+  id?: string;
+  json?: boolean;
+}
+
+export interface ReadDeps {
+  createRepo?: (url?: string, key?: string) => QdrantRepository;
+}
+
+const DISPLAY_ORDER = [
+  'id',
+  'repo',
+  'org',
+  'domain',
+  'entry_type',
+  'source',
+  'confidence',
+  'tags',
+  'rationale',
+  'commit',
+  'story',
+  'files_modified',
+  'relates_to',
+  'timestamp_utc',
+] as const;
+
+function requireId(value?: string): string {
+  const normalized = value?.trim() ?? '';
+  if (!normalized) {
+    throw new MemoError('VALIDATION_FAILED', 'Missing required --id value.');
+  }
+  return normalized;
+}
+
+function isPresent(value: unknown): boolean {
+  if (value === undefined || value === null) return false;
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+function formatValue(value: unknown): string {
+  if (Array.isArray(value)) return value.map((entry) => String(entry)).join(', ');
+  if (typeof value === 'object' && value !== null) return JSON.stringify(value);
+  return String(value);
+}
+
+function renderHuman(result: Record<string, unknown>): string {
+  const lines: string[] = [];
+
+  for (const key of DISPLAY_ORDER) {
+    const value = result[key];
+    if (!isPresent(value)) continue;
+    lines.push(`${key}: ${formatValue(value)}`);
+  }
+
+  for (const [key, value] of Object.entries(result)) {
+    if (DISPLAY_ORDER.includes(key as (typeof DISPLAY_ORDER)[number])) continue;
+    if (!isPresent(value)) continue;
+    lines.push(`${key}: ${formatValue(value)}`);
+  }
+
+  return lines.join('\n');
+}
+
+export async function handleRead(flags: ReadFlags, deps: ReadDeps = {}): Promise<void> {
+  const { createRepo = (url, key) => new QdrantRepository(url, key) } = deps;
+
+  const id = requireId(flags.id);
+  const qdrant = createRepo(process.env['QDRANT_URL'], process.env['QDRANT_API_KEY']);
+  await qdrant.ensureCollection();
+
+  const entry = await qdrant.getById(id);
+  if (!entry) {
+    throw new MemoError('ENTRY_NOT_FOUND', `Entry not found: ${id}`);
+  }
+
+  const response: Record<string, unknown> = {
+    ...(entry.payload ?? {}),
+    id: entry.id,
+  };
+
+  if (flags.json) {
+    output.result(response, { json: true });
+    return;
+  }
+
+  output.result(renderHuman(response));
+}
+
+const read = new Command('read')
+  .description('Read a single memo entry by id')
+  .requiredOption('--id <id>', 'entry id (Qdrant point id)')
+  .option('--json', 'output as JSON')
+  .action(async (opts: Record<string, unknown>) => {
+    await handleRead({
+      id: opts['id'] as string | undefined,
+      json: opts['json'] as boolean | undefined,
+    });
+  });
+
+export default read;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import list from './commands/list.js';
 import tags from './commands/tags.js';
 import inspect from './commands/inspect.js';
 import del from './commands/delete.js';
+import read from './commands/read.js';
 import { MemoError } from './lib/errors.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -32,6 +33,7 @@ program.addCommand(list);
 program.addCommand(tags);
 program.addCommand(inspect);
 program.addCommand(del);
+program.addCommand(read);
 
 let fatalHandled = false;
 

--- a/src/lib/qdrant.ts
+++ b/src/lib/qdrant.ts
@@ -157,6 +157,11 @@ export class QdrantRepository {
     return results[0] ?? null;
   }
 
+  async getById(id: string): Promise<ScrollResult | null> {
+    const results = await this.scroll({ must: [{ has_id: [id] }] }, 1);
+    return results[0] ?? null;
+  }
+
   async deleteById(id: string): Promise<void> {
     try {
       const existing = await this.scroll({ must: [{ has_id: [id] }] }, 1);

--- a/tests/integration/commands/read.test.ts
+++ b/tests/integration/commands/read.test.ts
@@ -1,0 +1,82 @@
+import { handleRead } from '../../../src/commands/read.js';
+import type { ReadDeps } from '../../../src/commands/read.js';
+
+const mockQdrant = {
+  ensureCollection: jest.fn().mockResolvedValue(undefined),
+  getById: jest.fn(),
+};
+
+let stdoutData = '';
+
+beforeEach(() => {
+  stdoutData = '';
+  jest.spyOn(process.stdout, 'write').mockImplementation((data: unknown) => {
+    stdoutData += String(data);
+    return true;
+  });
+  jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function deps(): ReadDeps {
+  return {
+    createRepo: () => mockQdrant as unknown as ReturnType<NonNullable<ReadDeps['createRepo']>>,
+  };
+}
+
+describe('read integration', () => {
+  it('reads one entry by id in human mode', async () => {
+    mockQdrant.getById.mockResolvedValueOnce({
+      id: 'entry-1',
+      payload: {
+        repo: 'memo-cli',
+        org: 'llipe',
+        entry_type: 'decision',
+        source: 'agent',
+        rationale: 'Use read command for direct lookup.',
+      },
+    });
+
+    await handleRead({ id: 'entry-1' }, deps());
+
+    expect(mockQdrant.ensureCollection).toHaveBeenCalled();
+    expect(mockQdrant.getById).toHaveBeenCalledWith('entry-1');
+    expect(stdoutData).toContain('id: entry-1');
+    expect(stdoutData).toContain('repo: memo-cli');
+    expect(stdoutData).toContain('entry_type: decision');
+  });
+
+  it('reads one entry by id in JSON mode', async () => {
+    mockQdrant.getById.mockResolvedValueOnce({
+      id: 'entry-2',
+      payload: {
+        repo: 'memo-cli',
+        tags: ['read', 'json'],
+        rationale: 'Return flat object in JSON mode.',
+      },
+    });
+
+    await handleRead({ id: 'entry-2', json: true }, deps());
+
+    const result = JSON.parse(stdoutData) as Record<string, unknown>;
+    expect(result).toEqual({
+      id: 'entry-2',
+      repo: 'memo-cli',
+      tags: ['read', 'json'],
+      rationale: 'Return flat object in JSON mode.',
+    });
+  });
+
+  it('returns ENTRY_NOT_FOUND for unknown id', async () => {
+    mockQdrant.getById.mockResolvedValueOnce(null);
+
+    await expect(handleRead({ id: 'missing-id' }, deps())).rejects.toMatchObject({
+      code: 'ENTRY_NOT_FOUND',
+      message: 'Entry not found: missing-id',
+    });
+  });
+});

--- a/tests/unit/commands/read.test.ts
+++ b/tests/unit/commands/read.test.ts
@@ -1,0 +1,96 @@
+import { handleRead } from '../../../src/commands/read.js';
+import type { ReadDeps } from '../../../src/commands/read.js';
+
+const mockQdrant = {
+  ensureCollection: jest.fn().mockResolvedValue(undefined),
+  getById: jest.fn(),
+};
+
+let stdoutData = '';
+
+beforeEach(() => {
+  stdoutData = '';
+  jest.spyOn(process.stdout, 'write').mockImplementation((data: unknown) => {
+    stdoutData += String(data);
+    return true;
+  });
+  jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  jest.clearAllMocks();
+  mockQdrant.getById.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function deps(): ReadDeps {
+  return {
+    createRepo: () => mockQdrant as unknown as ReturnType<NonNullable<ReadDeps['createRepo']>>,
+  };
+}
+
+describe('handleRead', () => {
+  it('throws VALIDATION_FAILED when --id is missing', async () => {
+    await expect(handleRead({}, deps())).rejects.toMatchObject({
+      code: 'VALIDATION_FAILED',
+      message: 'Missing required --id value.',
+    });
+  });
+
+  it('throws ENTRY_NOT_FOUND when id does not exist', async () => {
+    await expect(handleRead({ id: 'missing-id' }, deps())).rejects.toMatchObject({
+      code: 'ENTRY_NOT_FOUND',
+      message: 'Entry not found: missing-id',
+    });
+  });
+
+  it('renders human-readable entry output in stable order and omits empty fields', async () => {
+    mockQdrant.getById.mockResolvedValueOnce({
+      id: 'entry-123',
+      payload: {
+        repo: 'memo-cli',
+        org: 'llipe',
+        tags: ['read', 'entry'],
+        rationale: 'Read one exact entry by id',
+        timestamp_utc: '2026-07-09T12:00:00.000Z',
+        files_modified: [],
+        story: '',
+      },
+    });
+
+    await handleRead({ id: 'entry-123' }, deps());
+
+    expect(mockQdrant.ensureCollection).toHaveBeenCalled();
+    expect(mockQdrant.getById).toHaveBeenCalledWith('entry-123');
+    expect(stdoutData).toContain('id: entry-123');
+    expect(stdoutData).toContain('repo: memo-cli');
+    expect(stdoutData).toContain('org: llipe');
+    expect(stdoutData).toContain('tags: read, entry');
+    expect(stdoutData).toContain('rationale: Read one exact entry by id');
+    expect(stdoutData).toContain('timestamp_utc: 2026-07-09T12:00:00.000Z');
+    expect(stdoutData).not.toContain('files_modified:');
+    expect(stdoutData).not.toContain('story:');
+    expect(stdoutData.indexOf('id: entry-123')).toBeLessThan(stdoutData.indexOf('repo: memo-cli'));
+  });
+
+  it('returns flat payload JSON with id when --json is set', async () => {
+    mockQdrant.getById.mockResolvedValueOnce({
+      id: 'entry-999',
+      payload: {
+        repo: 'memo-cli',
+        entry_type: 'decision',
+        rationale: 'Machine-readable response',
+      },
+    });
+
+    await handleRead({ id: 'entry-999', json: true }, deps());
+
+    const result = JSON.parse(stdoutData) as Record<string, unknown>;
+    expect(result).toEqual({
+      id: 'entry-999',
+      repo: 'memo-cli',
+      entry_type: 'decision',
+      rationale: 'Machine-readable response',
+    });
+  });
+});

--- a/tests/unit/lib/qdrant.test.ts
+++ b/tests/unit/lib/qdrant.test.ts
@@ -142,6 +142,35 @@ describe('QdrantRepository', () => {
     });
   });
 
+  describe('getById()', () => {
+    it('returns the matching entry when found', async () => {
+      mockScroll.mockResolvedValueOnce({
+        points: [{ id: 'entry-1', payload: { repo: 'memo-cli' } }],
+      });
+
+      const repo = new QdrantRepository('http://localhost:6333');
+      const result = await repo.getById('entry-1');
+
+      expect(mockScroll).toHaveBeenCalledWith(
+        'decisions',
+        expect.objectContaining({
+          filter: { must: [{ has_id: ['entry-1'] }] },
+          limit: 1,
+        }),
+      );
+      expect(result).toEqual({ id: 'entry-1', payload: { repo: 'memo-cli' } });
+    });
+
+    it('returns null when id does not exist', async () => {
+      mockScroll.mockResolvedValueOnce({ points: [] });
+
+      const repo = new QdrantRepository('http://localhost:6333');
+      const result = await repo.getById('missing-id');
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe('deleteById()', () => {
     it('calls client.delete with points when id exists', async () => {
       mockScroll.mockResolvedValueOnce({ points: [{ id: 'entry-1', payload: {} }] });

--- a/workstream/issue-32-read-specific-id-refinement.md
+++ b/workstream/issue-32-read-specific-id-refinement.md
@@ -1,0 +1,84 @@
+# Issue Refinement: #32 - Read a Specific Memo Entry by ID
+
+## Changelog
+
+| Version | Date       | Summary                                                 | Author           |
+|---------|------------|---------------------------------------------------------|------------------|
+| 1.0     | 2026-07-09 | Refined existing issue and aligned CLI to `memo read` | product-engineer |
+| 1.1     | 2026-07-09 | Finalized naming: adopt `memo read --id` only         | product-engineer |
+
+## Summary
+
+- Goal: Provide a dedicated read command for fetching one exact memo entry by Qdrant point ID.
+- Preferred CLI: `memo read --id <id>` (example: `memo read --id 123`).
+- Primary user impact: Agents and developers can retrieve the full payload for one known entry without running semantic search or broad list queries.
+- Non-goals:
+  - Bulk reads.
+  - Changes to search ranking.
+  - Any write/update/delete behavior.
+
+## Problem Being Solved
+
+Today, users can discover entries with `memo search` and `memo list`, but there is no first-class command focused on reading one exact entry by ID. This creates friction in automation and manual inspection workflows where the entry ID is already known.
+
+## Scope and Command Contract
+
+- Command: `memo read --id <id>`
+- Required flag: `--id` (string, Qdrant point ID)
+- Optional flag: `--json` for machine-readable output
+- Behavior:
+  - Resolve one exact entry by ID.
+  - Return full stored payload.
+  - Read-only operation.
+
+## Acceptance Criteria
+
+- [ ] `memo read --id <id>` returns exactly one entry in human-readable format.
+- [ ] `memo read --id <id> --json` returns the full payload as a flat JSON object.
+- [ ] Missing `--id` fails with `VALIDATION_FAILED` and a clear message.
+- [ ] Non-existent ID fails with `ENTRY_NOT_FOUND` and exit code `1`.
+- [ ] Command does not require `memo.config.json`.
+- [ ] Command auto-ensures the collection before lookup (consistent with existing read operations).
+- [ ] Human output omits empty fields but includes all present payload fields.
+
+## Business Rules
+
+- ID is treated as an opaque string. No command-side UUID format enforcement is required unless already standardized elsewhere.
+- Lookup is globally scoped to the collection (no repo/org/domain filter required when ID is provided).
+- The command MUST NOT modify data.
+
+## Technical Notes
+
+- Add/confirm repository helper: `getById(id: string): Promise<ScrollResult | null>` in `src/lib/qdrant.ts`.
+- Add command implementation file: `src/commands/read.ts`.
+- Register command in `src/index.ts`.
+- Recommended human output field order:
+  - `id`, `repo`, `org`, `domain`, `entry_type`, `source`, `confidence`, `tags`, `rationale`, `commit`, `story`, `files_modified`, `relates_to`, `timestamp_utc`
+- In JSON mode, return payload fields without extra wrapper object.
+
+## Risks and Edge Cases
+
+- Invalid or stale IDs: return `ENTRY_NOT_FOUND`.
+- Empty payload fields: ensure output rendering omits empty values to avoid noisy output.
+- Potential naming confusion with previous proposal (`memo get <id>`): resolved by standardizing on `memo read --id <id>` in docs/tests.
+
+## Dependencies
+
+- Existing Qdrant repository read path and error taxonomy (`MemoError`).
+- Existing output module patterns for human/JSON rendering.
+
+## Testing Notes
+
+- Unit tests:
+  - Flag validation (`--id` required).
+  - Found/not-found behavior.
+  - Human vs JSON output shape.
+- Integration tests:
+  - End-to-end read by known ID.
+  - Not-found behavior with expected error code.
+- CLI docs/help text should include examples for `memo read --id` and `--json`.
+
+## Decision
+
+- Adopt `memo read --id <id>` as the only supported command contract for this story.
+- Do not add a `memo get` alias in this scope.

--- a/workstream/tasks-issue-32-read-specific-id.md
+++ b/workstream/tasks-issue-32-read-specific-id.md
@@ -1,0 +1,31 @@
+# Implementation Plan - Issue #32 Read Specific ID
+
+## Relevant Files
+
+- `src/lib/qdrant.ts` - Add/confirm repository helper to fetch one entry by ID.
+- `src/commands/read.ts` - Implement `memo read --id` command logic and output paths.
+- `src/index.ts` - Register the new `read` command.
+- `tests/unit/commands/read.test.ts` - Unit coverage for validation and output behavior.
+- `tests/unit/lib/qdrant.test.ts` - Unit coverage for `getById` repository helper.
+- `tests/integration/commands/read.test.ts` - End-to-end command behavior coverage.
+- `README.md` - Add command reference and usage examples for `memo read --id`.
+
+## Tasks
+
+- [ ] 1.0 Implement Issue #32 - https://github.com/llipe/memo-cli/issues/32: `memo read --id` read specific entry
+  - [ ] 1.1 Add or confirm `getById(id: string): Promise<ScrollResult | null>` in `src/lib/qdrant.ts`
+  - [ ] 1.2 Create `src/commands/read.ts` with `ReadFlags`, `ReadDeps`, and `handleRead()`
+  - [ ] 1.3 Validate command flags (`--id` required) and enforce read-only behavior
+  - [ ] 1.4 Implement human-readable output for a single entry, omitting empty fields
+  - [ ] 1.5 Implement `--json` output returning a flat payload object
+  - [ ] 1.6 Register `memo read` in `src/index.ts`
+  - [ ] 1.7 Update command docs/help examples in `README.md`
+  - [ ] 1.8 Verify Acceptance Criterion: found entry in human mode
+  - [ ] 1.9 Verify Acceptance Criterion: found entry in JSON mode
+  - [ ] 1.10 Verify Acceptance Criterion: missing `--id` returns `VALIDATION_FAILED`
+  - [ ] 1.11 Verify Acceptance Criterion: unknown ID returns `ENTRY_NOT_FOUND` with exit code `1`
+  - [ ] 1.12 Verify Acceptance Criterion: command works without `memo.config.json`
+  - [ ] 1.13 Run Tests: `tests/unit/commands/read.test.ts`
+  - [ ] 1.14 Run Tests: `tests/unit/lib/qdrant.test.ts` coverage for `getById`
+  - [ ] 1.15 Run Tests: `tests/integration/commands/read.test.ts`
+  - [ ] 1.16 Run Tests: `pnpm test -- --testPathPattern="read"`

--- a/workstream/tasks-issue-32-read-specific-id.md
+++ b/workstream/tasks-issue-32-read-specific-id.md
@@ -9,23 +9,27 @@
 - `tests/unit/lib/qdrant.test.ts` - Unit coverage for `getById` repository helper.
 - `tests/integration/commands/read.test.ts` - End-to-end command behavior coverage.
 - `README.md` - Add command reference and usage examples for `memo read --id`.
+- `docs/system-overview.md` - Add `memo read` to command inventory and read flow.
+- `docs/technical-guidelines.md` - Include `commands/read.ts` in architecture and command surface.
+- `docs/product-context.md` - Record issue #32 as delivered capability.
+- `docs/adr/ADR-002-document-read-command-in-canonical-docs.md` - ADR documenting canonical docs parity update.
 
 ## Tasks
 
-- [ ] 1.0 Implement Issue #32 - https://github.com/llipe/memo-cli/issues/32: `memo read --id` read specific entry
-  - [ ] 1.1 Add or confirm `getById(id: string): Promise<ScrollResult | null>` in `src/lib/qdrant.ts`
-  - [ ] 1.2 Create `src/commands/read.ts` with `ReadFlags`, `ReadDeps`, and `handleRead()`
-  - [ ] 1.3 Validate command flags (`--id` required) and enforce read-only behavior
-  - [ ] 1.4 Implement human-readable output for a single entry, omitting empty fields
-  - [ ] 1.5 Implement `--json` output returning a flat payload object
-  - [ ] 1.6 Register `memo read` in `src/index.ts`
-  - [ ] 1.7 Update command docs/help examples in `README.md`
-  - [ ] 1.8 Verify Acceptance Criterion: found entry in human mode
-  - [ ] 1.9 Verify Acceptance Criterion: found entry in JSON mode
-  - [ ] 1.10 Verify Acceptance Criterion: missing `--id` returns `VALIDATION_FAILED`
-  - [ ] 1.11 Verify Acceptance Criterion: unknown ID returns `ENTRY_NOT_FOUND` with exit code `1`
-  - [ ] 1.12 Verify Acceptance Criterion: command works without `memo.config.json`
-  - [ ] 1.13 Run Tests: `tests/unit/commands/read.test.ts`
-  - [ ] 1.14 Run Tests: `tests/unit/lib/qdrant.test.ts` coverage for `getById`
-  - [ ] 1.15 Run Tests: `tests/integration/commands/read.test.ts`
-  - [ ] 1.16 Run Tests: `pnpm test -- --testPathPattern="read"`
+- [x] 1.0 Implement Issue #32 - https://github.com/llipe/memo-cli/issues/32: `memo read --id` read specific entry
+  - [x] 1.1 Add or confirm `getById(id: string): Promise<ScrollResult | null>` in `src/lib/qdrant.ts`
+  - [x] 1.2 Create `src/commands/read.ts` with `ReadFlags`, `ReadDeps`, and `handleRead()`
+  - [x] 1.3 Validate command flags (`--id` required) and enforce read-only behavior
+  - [x] 1.4 Implement human-readable output for a single entry, omitting empty fields
+  - [x] 1.5 Implement `--json` output returning a flat payload object
+  - [x] 1.6 Register `memo read` in `src/index.ts`
+  - [x] 1.7 Update command docs/help examples in `README.md`
+  - [x] 1.8 Verify Acceptance Criterion: found entry in human mode
+  - [x] 1.9 Verify Acceptance Criterion: found entry in JSON mode
+  - [x] 1.10 Verify Acceptance Criterion: missing `--id` returns `VALIDATION_FAILED`
+  - [x] 1.11 Verify Acceptance Criterion: unknown ID returns `ENTRY_NOT_FOUND` with exit code `1`
+  - [x] 1.12 Verify Acceptance Criterion: command works without `memo.config.json`
+  - [x] 1.13 Run Tests: `tests/unit/commands/read.test.ts`
+  - [x] 1.14 Run Tests: `tests/unit/lib/qdrant.test.ts` coverage for `getById`
+  - [x] 1.15 Run Tests: `tests/integration/commands/read.test.ts`
+  - [x] 1.16 Run Tests: `pnpm test -- --testPathPattern="read"`


### PR DESCRIPTION
This pull request introduces the new `memo read --id` command, which allows users to fetch a single memo entry by its unique ID, with support for both human-readable and JSON output. The implementation includes the command logic, integration into the CLI, updates to the Qdrant repository, and comprehensive documentation and tests. Additionally, canonical documentation and project structure references are updated to ensure full alignment with the new command.

**New Command Implementation:**

* Added `src/commands/read.ts` implementing the `memo read --id` command, which validates the ID, fetches the entry from Qdrant, and outputs the result in human or JSON format.
* Registered the new command in the CLI entrypoint (`src/index.ts`) so it is available as a top-level command. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R14) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R36)
* Added `getById(id)` method to `QdrantRepository` for efficient single-entry lookup by ID.

**Documentation Updates:**

* Updated `README.md` to include usage instructions, command reference, and project structure for `memo read`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R511-R537) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R551) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L693-R723)
* Added an Architecture Decision Record (`docs/adr/ADR-002-document-read-command-in-canonical-docs.md`) documenting the rationale and scope of the documentation updates.
* Updated canonical docs (`docs/system-overview.md`, `docs/technical-guidelines.md`, `docs/product-context.md`) to reflect the new command in inventories, command trees, and capability tables. [[1]](diffhunk://#diff-2439d5201248b88cf0d56590dcbc4cc47a43bb7b4a61befeaf83271c82b641fdR47) [[2]](diffhunk://#diff-2439d5201248b88cf0d56590dcbc4cc47a43bb7b4a61befeaf83271c82b641fdR154-R161) [[3]](diffhunk://#diff-7bf7f2bc485f3bcb916461999cd8ba5593660661aaa46b607102d867cdf6cb01L83-R84) [[4]](diffhunk://#diff-7bf7f2bc485f3bcb916461999cd8ba5593660661aaa46b607102d867cdf6cb01L422-R427) [[5]](diffhunk://#diff-c5ae370554ff9b1f3a975e002d4944246bc2973bc2cff36837dfb81e551423f2R74)

**Testing:**

* Added integration and unit tests for the new command (`tests/integration/commands/read.test.ts`, `tests/unit/commands/read.test.ts`) covering human and JSON modes, validation, and error handling. [[1]](diffhunk://#diff-e08deffc3904312fde8491cb41bf4c5e00e7179356bb0a319b806940b3911d13R1-R82) [[2]](diffhunk://#diff-282b2c63a2ec1d0237b09c4e8da81f2c1994e0e2b23fa9925b486bec71912ff1R1-R96)
* Added unit tests for the new `getById()` repository method.

No breaking changes or modifications to existing commands were made. The codebase and documentation are now consistent and fully represent the current CLI capabilities.